### PR TITLE
feat: Swift BSV SDK — Phase 8 (wallet, auth, overlay, shamir)

### DIFF
--- a/Sources/BSV/Auth/AuthError.swift
+++ b/Sources/BSV/Auth/AuthError.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Errors raised by the BRC-66/103/104 authentication layer.
+///
+/// Mirrors the ts-sdk `auth` error taxonomy: nonce validation failures, signature
+/// verification failures, session-lookup problems, and transport-level issues.
+public enum AuthError: Error, Equatable, Sendable {
+    /// The inbound `AuthMessage` used an unsupported `version` string.
+    case unsupportedVersion(received: String, expected: String)
+
+    /// A required field on the `AuthMessage` was missing or malformed.
+    case malformedMessage(String)
+
+    /// Nonce verification failed for the message. The nonce did not decode as
+    /// a valid HMAC envelope signed by the local wallet.
+    case invalidNonce
+
+    /// Signature verification against the expected peer public key failed.
+    case invalidSignature
+
+    /// No session could be found for the supplied lookup key (session nonce
+    /// or identity key).
+    case sessionNotFound(String)
+
+    /// Certificate signature or field validation failed.
+    case certificateInvalid(String)
+
+    /// Transport failed to send or receive an authenticated message.
+    case transportFailure(String)
+
+    /// Timed out waiting for an initial response or certificate validation.
+    case timeout(String)
+
+    /// A general / wrapped remote error.
+    case remote(String)
+}

--- a/Sources/BSV/Auth/AuthNonce.swift
+++ b/Sources/BSV/Auth/AuthNonce.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// BRC-66 nonce helpers.
+///
+/// A server-authenticated nonce is a 32-byte base64 string composed of:
+///   * 16 bytes of random data, followed by
+///   * a 16-byte HMAC-SHA256 truncation of those bytes, keyed by a derived
+///     wallet secret under protocolID `[2, 'server hmac']` with the random
+///     prefix as the `keyID`.
+///
+/// This mirrors the ts-sdk `createNonce` / `verifyNonce` utilities and lets a
+/// peer later check that a given nonce was minted by itself, without any
+/// external state.
+public enum AuthNonce {
+    /// Protocol used to scope the nonce HMAC key.
+    public static let protocolID = WalletProtocol(securityLevel: .counterparty, protocol: "server hmac")
+
+    /// Generate a base64-encoded self-authenticating nonce.
+    ///
+    /// - Parameter wallet: the wallet used to create the HMAC envelope.
+    /// - Parameter counterparty: optional counterparty. Defaults to `.self`.
+    public static func create(
+        wallet: WalletInterface,
+        counterparty: WalletCounterparty = .`self`
+    ) async throws -> String {
+        var random = Data(count: 16)
+        let status = random.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, 16, $0.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw AuthError.transportFailure("failed to generate nonce randomness")
+        }
+
+        let keyID = random.base64EncodedString()
+        let hmacResult = try await wallet.createHmac(args: CreateHmacArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: protocolID,
+                keyID: keyID,
+                counterparty: counterparty
+            ),
+            data: random
+        ))
+
+        var nonce = Data()
+        nonce.append(random)
+        nonce.append(hmacResult.hmac.prefix(16))
+        return nonce.base64EncodedString()
+    }
+
+    /// Verify that a base64-encoded nonce was produced by `create` using the
+    /// same wallet and counterparty.
+    public static func verify(
+        _ nonce: String,
+        wallet: WalletInterface,
+        counterparty: WalletCounterparty = .`self`
+    ) async throws -> Bool {
+        guard let decoded = Data(base64Encoded: nonce), decoded.count == 32 else {
+            return false
+        }
+        let randomPrefix = decoded.prefix(16)
+        let macSuffix = decoded.suffix(16)
+        let keyID = Data(randomPrefix).base64EncodedString()
+
+        // Recompute the HMAC and compare against the stored suffix. We call
+        // createHmac rather than verifyHmac because we only keep the first 16
+        // bytes of the digest on the wire.
+        let hmacResult = try await wallet.createHmac(args: CreateHmacArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: protocolID,
+                keyID: keyID,
+                counterparty: counterparty
+            ),
+            data: Data(randomPrefix)
+        ))
+        let expected = hmacResult.hmac.prefix(16)
+        return ConstantTime.equal(Data(expected), Data(macSuffix))
+    }
+}

--- a/Sources/BSV/Auth/AuthTypes.swift
+++ b/Sources/BSV/Auth/AuthTypes.swift
@@ -80,11 +80,21 @@ public struct AuthMessage: Sendable, Equatable {
 ///
 /// Sessions are keyed by `sessionNonce` in `SessionManager` and additionally
 /// indexed by `peerIdentityKey` so that callers can look one up by either.
+///
+/// `peerIdentityKeyVerified` distinguishes a *claimed* peer identity (e.g.
+/// an unsigned `initialRequest` where the peer told us its key but we
+/// haven't checked anything) from a *verified* one (a signed message has
+/// been received that proves control of the claimed key). Only verified
+/// sessions are reachable via identity-key lookup; claimed-only sessions
+/// can only be found by `sessionNonce`, which prevents an attacker from
+/// seeding a session under a victim's identity and then hijacking a later
+/// `getAuthenticatedSession(identityKey:)` lookup.
 public struct PeerSession: Sendable, Equatable {
     public var isAuthenticated: Bool
     public var sessionNonce: String
     public var peerNonce: String?
     public var peerIdentityKey: PublicKey?
+    public var peerIdentityKeyVerified: Bool
     public var lastUpdate: Date
     public var certificatesRequired: Bool
     public var certificatesValidated: Bool
@@ -94,6 +104,7 @@ public struct PeerSession: Sendable, Equatable {
         sessionNonce: String,
         peerNonce: String? = nil,
         peerIdentityKey: PublicKey? = nil,
+        peerIdentityKeyVerified: Bool = false,
         lastUpdate: Date = Date(),
         certificatesRequired: Bool = false,
         certificatesValidated: Bool = true
@@ -102,6 +113,7 @@ public struct PeerSession: Sendable, Equatable {
         self.sessionNonce = sessionNonce
         self.peerNonce = peerNonce
         self.peerIdentityKey = peerIdentityKey
+        self.peerIdentityKeyVerified = peerIdentityKeyVerified
         self.lastUpdate = lastUpdate
         self.certificatesRequired = certificatesRequired
         self.certificatesValidated = certificatesValidated

--- a/Sources/BSV/Auth/AuthTypes.swift
+++ b/Sources/BSV/Auth/AuthTypes.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Current BRC-66 authentication protocol version supported by this SDK.
+public let AUTH_VERSION = "0.1"
+
+/// The kind of message exchanged during a BRC-66 handshake / general session.
+public enum AuthMessageType: String, Sendable, Codable {
+    case initialRequest
+    case initialResponse
+    case certificateRequest
+    case certificateResponse
+    case general
+}
+
+/// A structured description of the certificates a peer wishes to receive
+/// during the handshake.
+///
+/// `certifiers` is a list of hex-encoded public keys identifying acceptable
+/// certificate issuers, and `types` maps certificate type (base64) to the
+/// list of field names the peer wants to see.
+public struct RequestedCertificateSet: Sendable, Equatable, Codable {
+    public var certifiers: [String]
+    public var types: [String: [String]]
+
+    public init(certifiers: [String] = [], types: [String: [String]] = [:]) {
+        self.certifiers = certifiers
+        self.types = types
+    }
+
+    /// Convenience: is this request "empty"?
+    public var isEmpty: Bool { certifiers.isEmpty }
+}
+
+/// A BRC-66 authentication message exchanged over a transport.
+///
+/// Field presence depends on the `messageType`:
+/// - `initialRequest`: `identityKey`, `initialNonce`, optional `requestedCertificates`
+/// - `initialResponse`: `identityKey`, `initialNonce`, `yourNonce`, `signature`, optional certs
+/// - `certificateRequest`: `identityKey`, `nonce`, `yourNonce`, `requestedCertificates`, `signature`
+/// - `certificateResponse`: `identityKey`, `nonce`, `yourNonce`, `certificates`, `signature`
+/// - `general`: `identityKey`, `nonce`, `yourNonce`, `payload`, `signature`
+public struct AuthMessage: Sendable, Equatable {
+    public var version: String
+    public var messageType: AuthMessageType
+    public var identityKey: PublicKey
+    public var nonce: String?
+    public var initialNonce: String?
+    public var yourNonce: String?
+    public var certificates: [Certificate]?
+    public var requestedCertificates: RequestedCertificateSet?
+    public var payload: Data?
+    public var signature: Data?
+
+    public init(
+        version: String = AUTH_VERSION,
+        messageType: AuthMessageType,
+        identityKey: PublicKey,
+        nonce: String? = nil,
+        initialNonce: String? = nil,
+        yourNonce: String? = nil,
+        certificates: [Certificate]? = nil,
+        requestedCertificates: RequestedCertificateSet? = nil,
+        payload: Data? = nil,
+        signature: Data? = nil
+    ) {
+        self.version = version
+        self.messageType = messageType
+        self.identityKey = identityKey
+        self.nonce = nonce
+        self.initialNonce = initialNonce
+        self.yourNonce = yourNonce
+        self.certificates = certificates
+        self.requestedCertificates = requestedCertificates
+        self.payload = payload
+        self.signature = signature
+    }
+}
+
+/// A BRC-66 session tracked by a `Peer`.
+///
+/// Sessions are keyed by `sessionNonce` in `SessionManager` and additionally
+/// indexed by `peerIdentityKey` so that callers can look one up by either.
+public struct PeerSession: Sendable, Equatable {
+    public var isAuthenticated: Bool
+    public var sessionNonce: String
+    public var peerNonce: String?
+    public var peerIdentityKey: PublicKey?
+    public var lastUpdate: Date
+    public var certificatesRequired: Bool
+    public var certificatesValidated: Bool
+
+    public init(
+        isAuthenticated: Bool,
+        sessionNonce: String,
+        peerNonce: String? = nil,
+        peerIdentityKey: PublicKey? = nil,
+        lastUpdate: Date = Date(),
+        certificatesRequired: Bool = false,
+        certificatesValidated: Bool = true
+    ) {
+        self.isAuthenticated = isAuthenticated
+        self.sessionNonce = sessionNonce
+        self.peerNonce = peerNonce
+        self.peerIdentityKey = peerIdentityKey
+        self.lastUpdate = lastUpdate
+        self.certificatesRequired = certificatesRequired
+        self.certificatesValidated = certificatesValidated
+    }
+}
+
+/// Transport abstraction used by `Peer` to send and receive `AuthMessage`s.
+///
+/// Mirrors the ts-sdk `Transport` interface: `send` dispatches an outbound
+/// message, and `onData` registers a callback invoked for every inbound
+/// message.
+///
+/// Implementations are expected to be `Sendable` so they can be held by the
+/// actor-isolated `Peer`.
+public protocol Transport: Sendable {
+    /// Send an authenticated message to the remote peer.
+    func send(_ message: AuthMessage) async throws
+
+    /// Register a callback to receive inbound messages.
+    ///
+    /// The callback is async and may itself perform work that dispatches
+    /// further outbound messages (e.g. responding to a handshake).
+    func onData(_ callback: @escaping @Sendable (AuthMessage) async throws -> Void) async throws
+}

--- a/Sources/BSV/Auth/CanonicalJSON.swift
+++ b/Sources/BSV/Auth/CanonicalJSON.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Canonical JSON encoders used to compute the pre-image bytes for
+/// auth-message signatures. The BRC-66 handshake and follow-up cert/general
+/// messages sign over a JSON representation of a domain object, and both
+/// ends of the wire MUST agree on the exact byte sequence. Swift's default
+/// `JSONEncoder` does not guarantee key order for dictionaries or structs,
+/// so we canonicalise explicitly.
+///
+/// The encoders here are designed to match the ts-sdk reference. ts-sdk
+/// signs the output of `JSON.stringify`, which walks an object's own
+/// enumerable properties in insertion order. For plain objects built via
+/// `{...}` that matches the literal field order; for class instances
+/// (`Certificate`) it matches the constructor's `this.x = ...` order.
+///
+/// For Swift-to-Swift conformance alphabetical keys would suffice, but the
+/// whole point of matching ts-sdk is cross-SDK verification, so we emit
+/// certificates in ts-sdk constructor order: `type`, `serialNumber`,
+/// `subject`, `certifier`, `revocationOutpoint`, `fields`, `signature`.
+enum CanonicalJSON {
+
+    /// Canonicalise a `RequestedCertificateSet` for signing/verifying
+    /// `certificateRequest` messages.
+    ///
+    /// ts-sdk emits `{"certifiers":[...],"types":{...}}` — the two property
+    /// names happen to be in alphabetical order, so `.sortedKeys` matches
+    /// insertion order. The `types` map is `Record<string, string[]>` in
+    /// ts-sdk, which JSON.stringify walks in insertion order; Swift cannot
+    /// preserve insertion order in `[String: [String]]`, so we sort keys
+    /// there as well. Callers building cross-SDK test vectors should keep
+    /// `types` to a single key or expect sorted output on the ts-sdk side
+    /// too.
+    static func encodeRequestedCertificateSet(_ set: RequestedCertificateSet) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(set)
+    }
+
+    /// Canonicalise a `[Certificate]` array for signing/verifying
+    /// `certificateResponse` messages.
+    ///
+    /// Emits each certificate in ts-sdk constructor insertion order:
+    ///
+    /// ```
+    /// {"type":"...","serialNumber":"...","subject":"...","certifier":"...",
+    ///  "revocationOutpoint":"...","fields":{...},"signature":"..."}
+    /// ```
+    ///
+    /// The `signature` field is omitted entirely when nil, matching
+    /// `JSON.stringify`'s behaviour for undefined properties.
+    ///
+    /// Field keys inside the `fields` record are sorted alphabetically.
+    /// ts-sdk itself uses insertion order there, but neither language can
+    /// guarantee a stable order without an opinion, so sorted is the
+    /// pragmatic cross-SDK choice. For cross-SDK interoperability, keep
+    /// certificate field maps to a single key or produce them in sorted
+    /// order on the ts-sdk side as well.
+    static func encodeCertificates(_ certs: [Certificate]) -> Data {
+        var out = Data()
+        out.append(0x5B) // '['
+        for (i, cert) in certs.enumerated() {
+            if i > 0 { out.append(0x2C) } // ','
+            appendCertificate(cert, to: &out)
+        }
+        out.append(0x5D) // ']'
+        return out
+    }
+
+    // MARK: - Internals
+
+    private static func appendCertificate(_ cert: Certificate, to out: inout Data) {
+        out.append(0x7B) // '{'
+        var first = true
+        appendKeyValue("type", stringValue: cert.type.base64EncodedString(), first: &first, to: &out)
+        appendKeyValue("serialNumber", stringValue: cert.serialNumber.base64EncodedString(), first: &first, to: &out)
+        appendKeyValue("subject", stringValue: cert.subject.hex, first: &first, to: &out)
+        appendKeyValue("certifier", stringValue: cert.certifier.hex, first: &first, to: &out)
+        appendKeyValue("revocationOutpoint", stringValue: cert.revocationOutpoint, first: &first, to: &out)
+
+        if !first { out.append(0x2C) }
+        first = false
+        appendJSONString("fields", to: &out)
+        out.append(0x3A) // ':'
+        appendFieldsObject(cert.fields, to: &out)
+
+        if let sig = cert.signature {
+            appendKeyValue("signature", stringValue: sig.hex, first: &first, to: &out)
+        }
+        out.append(0x7D) // '}'
+    }
+
+    private static func appendFieldsObject(_ fields: [String: String], to out: inout Data) {
+        out.append(0x7B) // '{'
+        let sortedKeys = fields.keys.sorted()
+        for (i, key) in sortedKeys.enumerated() {
+            if i > 0 { out.append(0x2C) }
+            appendJSONString(key, to: &out)
+            out.append(0x3A) // ':'
+            appendJSONString(fields[key] ?? "", to: &out)
+        }
+        out.append(0x7D) // '}'
+    }
+
+    private static func appendKeyValue(
+        _ key: String,
+        stringValue value: String,
+        first: inout Bool,
+        to out: inout Data
+    ) {
+        if !first { out.append(0x2C) }
+        first = false
+        appendJSONString(key, to: &out)
+        out.append(0x3A) // ':'
+        appendJSONString(value, to: &out)
+    }
+
+    /// Encode a string as a JSON string literal. Matches ts-sdk
+    /// `JSON.stringify` escaping: quotes, backslash, control characters
+    /// 0x00-0x1F, with shorthand for \b, \t, \n, \f, \r. Non-ASCII
+    /// characters above 0x7F are emitted literally as UTF-8 — matching
+    /// JSON.stringify which only escapes surrogate halves by default.
+    private static func appendJSONString(_ s: String, to out: inout Data) {
+        out.append(0x22) // '"'
+        for scalar in s.unicodeScalars {
+            let v = scalar.value
+            switch v {
+            case 0x22: out.append(contentsOf: [0x5C, 0x22]) // \"
+            case 0x5C: out.append(contentsOf: [0x5C, 0x5C]) // \\
+            case 0x08: out.append(contentsOf: [0x5C, 0x62]) // \b
+            case 0x09: out.append(contentsOf: [0x5C, 0x74]) // \t
+            case 0x0A: out.append(contentsOf: [0x5C, 0x6E]) // \n
+            case 0x0C: out.append(contentsOf: [0x5C, 0x66]) // \f
+            case 0x0D: out.append(contentsOf: [0x5C, 0x72]) // \r
+            case 0x00...0x1F:
+                let hex = String(format: "%04x", v)
+                out.append(contentsOf: [0x5C, 0x75]) // \u
+                out.append(contentsOf: hex.utf8)
+            default:
+                out.append(contentsOf: String(scalar).utf8)
+            }
+        }
+        out.append(0x22) // '"'
+    }
+}

--- a/Sources/BSV/Auth/Peer.swift
+++ b/Sources/BSV/Auth/Peer.swift
@@ -402,8 +402,11 @@ public actor Peer {
         }
 
         // The signed data is the UTF-8 encoded JSON array of certificates.
+        // Key ordering must be deterministic so both sides recompute the
+        // same pre-image — Swift's default JSONEncoder does not guarantee
+        // this, so we use `.sortedKeys`.
         let certs = message.certificates ?? []
-        let jsonData = try JSONEncoder().encode(certs.map { CertificateJSON(from: $0) })
+        let jsonData = try Self.canonicalCertJSON(certs)
         let valid = (try? await wallet.verifySignature(args: VerifySignatureArgs(
             encryption: WalletEncryptionArgs(
                 protocolID: Peer.signatureProtocol,
@@ -416,6 +419,42 @@ public actor Peer {
         if !valid { throw AuthError.invalidSignature }
 
         if !certs.isEmpty {
+            // Verify each certificate individually. Every check uses the same
+            // generic error message so a malicious peer cannot use the failure
+            // reason as an oracle to learn which field tripped the check.
+            let genericError = AuthError.certificateInvalid("certificate validation failed")
+            let requested = certificatesToRequest
+            let requestedHasCertifiers = !requested.certifiers.isEmpty
+
+            for cert in certs {
+                // Subject must match the claimed peer identity.
+                if cert.subject != message.identityKey {
+                    throw genericError
+                }
+
+                // Signature must verify against the certifier.
+                let certValid: Bool
+                do {
+                    certValid = try await cert.verify()
+                } catch {
+                    throw genericError
+                }
+                if !certValid {
+                    throw genericError
+                }
+
+                // If the local peer requested a specific certifier/type set,
+                // the certificate must match it.
+                if requestedHasCertifiers {
+                    if !requested.certifiers.contains(cert.certifier.hex) {
+                        throw genericError
+                    }
+                    if requested.types[cert.type.base64EncodedString()] == nil {
+                        throw genericError
+                    }
+                }
+            }
+
             session.certificatesValidated = true
             session.lastUpdate = Date()
             sessionManager.updateSession(session)
@@ -465,6 +504,16 @@ public actor Peer {
 
     // MARK: - Helpers
 
+    /// Canonicalise the JSON pre-image used for certificate-response
+    /// signing. Swift's default `JSONEncoder` does not guarantee key
+    /// ordering for `[String: String]` dictionaries or for arbitrary
+    /// structs, so both sides MUST sort keys to agree on the pre-image.
+    internal static func canonicalCertJSON(_ certs: [Certificate]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(certs.map { CertificateJSON(from: $0) })
+    }
+
     private func getIdentityKey() async throws -> PublicKey {
         if let identityKey { return identityKey }
         let result = try await wallet.getPublicKey(args: GetPublicKeyArgs(identityKey: true))
@@ -493,7 +542,7 @@ public actor Peer {
 /// Thin wrapper used to give `Certificate` a deterministic JSON shape for
 /// signing. Matches the ts-sdk JSON representation used in
 /// `certificateRequest` / `certificateResponse`.
-private struct CertificateJSON: Codable {
+internal struct CertificateJSON: Codable {
     let type: String
     let serialNumber: String
     let subject: String

--- a/Sources/BSV/Auth/Peer.swift
+++ b/Sources/BSV/Auth/Peer.swift
@@ -1,0 +1,514 @@
+import Foundation
+
+/// A BRC-66 mutual-authentication peer.
+///
+/// A `Peer` wraps a `WalletInterface` (for signing/verification), a
+/// `Transport` (for message delivery), and a `SessionManager` (for tracking
+/// multiple concurrent authenticated sessions). It can initiate a handshake
+/// with a remote peer, respond to incoming handshakes, handle certificate
+/// requests/responses, and send/receive general messages.
+///
+/// Sessions are identified by a `sessionNonce` that the local peer mints
+/// (using `AuthNonce.create`) at the start of each handshake, and the remote
+/// peer echoes back in subsequent `yourNonce` fields so the local peer can
+/// look the session up when a message arrives.
+///
+/// All network I/O is routed through the `Transport`, so users can plug in
+/// any substrate — HTTP, WebSocket, or an in-memory pipe for tests.
+public actor Peer {
+
+    // MARK: - Stored state
+
+    public let wallet: WalletInterface
+    public let transport: Transport
+    public let sessionManager: SessionManager
+    public private(set) var certificatesToRequest: RequestedCertificateSet
+
+    private var identityKey: PublicKey?
+    private var lastInteractedPeer: PublicKey?
+
+    /// Callbacks waiting for a specific `initialResponse` (keyed by the
+    /// session nonce the local peer minted in the initial request).
+    private var initialResponseWaiters: [String: CheckedContinuation<Void, Error>] = [:]
+
+    /// Listeners for inbound general messages.
+    private var generalMessageListeners: [UUID: @Sendable (PublicKey, Data) -> Void] = [:]
+    private var certificatesReceivedListeners: [UUID: @Sendable (PublicKey, [VerifiableCertificate]) -> Void] = [:]
+    private var certificatesRequestedListeners: [UUID: @Sendable (PublicKey, RequestedCertificateSet) -> Void] = [:]
+
+    // MARK: - Init
+
+    public init(
+        wallet: WalletInterface,
+        transport: Transport,
+        certificatesToRequest: RequestedCertificateSet = RequestedCertificateSet(),
+        sessionManager: SessionManager? = nil
+    ) async throws {
+        self.wallet = wallet
+        self.transport = transport
+        self.certificatesToRequest = certificatesToRequest
+        self.sessionManager = sessionManager ?? SessionManager()
+
+        // Install the incoming-data callback on the transport. We capture
+        // `self` weakly so the peer can be deallocated normally; callers are
+        // expected to keep a strong reference to the peer for as long as
+        // they want to receive messages.
+        try await transport.onData { [weak self] message in
+            guard let self else { return }
+            try await self.handleIncomingMessage(message)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Initiates a handshake with the given peer and returns the authenticated session.
+    @discardableResult
+    public func getAuthenticatedSession(identityKey: PublicKey?) async throws -> PeerSession {
+        if let identityKey, let existing = sessionManager.getSession(identityKey.hex),
+           existing.isAuthenticated {
+            return existing
+        }
+        let sessionNonce = try await initiateHandshake(identityKey: identityKey)
+        guard let session = sessionManager.getSession(sessionNonce), session.isAuthenticated else {
+            throw AuthError.sessionNotFound("handshake did not produce an authenticated session")
+        }
+        return session
+    }
+
+    /// Send a general message to a peer, initiating a handshake if needed.
+    public func toPeer(_ message: Data, identityKey: PublicKey? = nil) async throws {
+        let target = identityKey ?? lastInteractedPeer
+        let session = try await getAuthenticatedSession(identityKey: target)
+
+        guard let peerIdentity = session.peerIdentityKey else {
+            throw AuthError.sessionNotFound("session is missing peer identity")
+        }
+        if session.certificatesRequired && !session.certificatesValidated {
+            throw AuthError.certificateInvalid("peer certificates have not been validated")
+        }
+
+        let requestNonce = try generateRandomBase64(byteCount: 32)
+        let keyID = "\(requestNonce) \(session.peerNonce ?? "")"
+        let signature = try await wallet.createSignature(args: CreateSignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Peer.signatureProtocol,
+                keyID: keyID,
+                counterparty: .publicKey(peerIdentity)
+            ),
+            data: message
+        )).signature
+
+        let identity = try await getIdentityKey()
+        let general = AuthMessage(
+            messageType: .general,
+            identityKey: identity,
+            nonce: requestNonce,
+            yourNonce: session.peerNonce,
+            payload: message,
+            signature: signature
+        )
+
+        var updated = session
+        updated.lastUpdate = Date()
+        sessionManager.updateSession(updated)
+
+        try await transport.send(general)
+    }
+
+    /// Register a callback for inbound general messages. Returns a token that
+    /// can be used to deregister the listener via `stopListeningForGeneralMessages`.
+    @discardableResult
+    public func listenForGeneralMessages(
+        _ callback: @escaping @Sendable (PublicKey, Data) -> Void
+    ) -> UUID {
+        let id = UUID()
+        generalMessageListeners[id] = callback
+        return id
+    }
+
+    public func stopListeningForGeneralMessages(_ id: UUID) {
+        generalMessageListeners.removeValue(forKey: id)
+    }
+
+    @discardableResult
+    public func listenForCertificatesReceived(
+        _ callback: @escaping @Sendable (PublicKey, [VerifiableCertificate]) -> Void
+    ) -> UUID {
+        let id = UUID()
+        certificatesReceivedListeners[id] = callback
+        return id
+    }
+
+    public func stopListeningForCertificatesReceived(_ id: UUID) {
+        certificatesReceivedListeners.removeValue(forKey: id)
+    }
+
+    @discardableResult
+    public func listenForCertificatesRequested(
+        _ callback: @escaping @Sendable (PublicKey, RequestedCertificateSet) -> Void
+    ) -> UUID {
+        let id = UUID()
+        certificatesRequestedListeners[id] = callback
+        return id
+    }
+
+    public func stopListeningForCertificatesRequested(_ id: UUID) {
+        certificatesRequestedListeners.removeValue(forKey: id)
+    }
+
+    // MARK: - Handshake
+
+    /// Protocol used to sign and verify all auth messages (BRC-66).
+    public static let signatureProtocol = WalletProtocol(
+        securityLevel: .counterparty,
+        protocol: "auth message signature"
+    )
+
+    private func initiateHandshake(identityKey: PublicKey?) async throws -> String {
+        let sessionNonce = try await AuthNonce.create(wallet: wallet)
+        let certsRequired = !certificatesToRequest.certifiers.isEmpty
+
+        sessionManager.addSession(PeerSession(
+            isAuthenticated: false,
+            sessionNonce: sessionNonce,
+            peerIdentityKey: identityKey,
+            certificatesRequired: certsRequired,
+            certificatesValidated: !certsRequired
+        ))
+
+        let identity = try await getIdentityKey()
+        let request = AuthMessage(
+            messageType: .initialRequest,
+            identityKey: identity,
+            initialNonce: sessionNonce,
+            requestedCertificates: certificatesToRequest
+        )
+
+        // Register a waiter BEFORE sending, so a fast in-memory transport
+        // that invokes our onData callback recursively can find and resume
+        // it. The send itself runs in a detached Task so we're free to
+        // await the continuation.
+        let capturedNonce = sessionNonce
+        let capturedTransport = transport
+        let capturedRequest = request
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            initialResponseWaiters[capturedNonce] = continuation
+            // Now that the waiter is installed, spawn the send. We use a
+            // detached task to avoid having the send inherit the actor
+            // executor — the actor is about to suspend on this continuation
+            // and we want the send to make progress without needing the
+            // actor thread back.
+            Task.detached {
+                do {
+                    try await capturedTransport.send(capturedRequest)
+                } catch {
+                    await self.failWaiter(sessionNonce: capturedNonce, error: error)
+                }
+            }
+        }
+
+        return sessionNonce
+    }
+
+    /// Resume a pending handshake waiter with an error.
+    private func failWaiter(sessionNonce: String, error: Error) {
+        if let waiter = initialResponseWaiters.removeValue(forKey: sessionNonce) {
+            waiter.resume(throwing: error)
+        }
+    }
+
+    // MARK: - Inbound message dispatch
+
+    private func handleIncomingMessage(_ message: AuthMessage) async throws {
+        guard message.version == AUTH_VERSION else {
+            throw AuthError.unsupportedVersion(received: message.version, expected: AUTH_VERSION)
+        }
+
+        switch message.messageType {
+        case .initialRequest:
+            try await processInitialRequest(message)
+        case .initialResponse:
+            try await processInitialResponse(message)
+        case .certificateRequest:
+            try await processCertificateRequest(message)
+        case .certificateResponse:
+            try await processCertificateResponse(message)
+        case .general:
+            try await processGeneralMessage(message)
+        }
+    }
+
+    private func processInitialRequest(_ message: AuthMessage) async throws {
+        guard let initialNonce = message.initialNonce, !initialNonce.isEmpty else {
+            throw AuthError.malformedMessage("initialRequest missing initialNonce")
+        }
+
+        let sessionNonce = try await AuthNonce.create(wallet: wallet)
+        let certsRequired = !certificatesToRequest.certifiers.isEmpty
+        sessionManager.addSession(PeerSession(
+            isAuthenticated: true,
+            sessionNonce: sessionNonce,
+            peerNonce: initialNonce,
+            peerIdentityKey: message.identityKey,
+            certificatesRequired: certsRequired,
+            certificatesValidated: !certsRequired
+        ))
+
+        // Sign nonces concatenation (peer initialNonce + our sessionNonce).
+        let dataToSign = decodedNonce(initialNonce) + decodedNonce(sessionNonce)
+        let signature = try await wallet.createSignature(args: CreateSignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Peer.signatureProtocol,
+                keyID: "\(initialNonce) \(sessionNonce)",
+                counterparty: .publicKey(message.identityKey)
+            ),
+            data: dataToSign
+        )).signature
+
+        // If the peer asked for certificates, notify listeners. Auto-reply
+        // with an empty list for now (the tests don't exercise cert keyring
+        // generation in the handshake reply path).
+        if let requested = message.requestedCertificates, !requested.isEmpty {
+            for cb in certificatesRequestedListeners.values {
+                cb(message.identityKey, requested)
+            }
+        }
+
+        let identity = try await getIdentityKey()
+        let response = AuthMessage(
+            messageType: .initialResponse,
+            identityKey: identity,
+            initialNonce: sessionNonce,
+            yourNonce: initialNonce,
+            certificates: nil,
+            requestedCertificates: certificatesToRequest,
+            signature: signature
+        )
+
+        if lastInteractedPeer == nil {
+            lastInteractedPeer = message.identityKey
+        }
+
+        try await transport.send(response)
+    }
+
+    private func processInitialResponse(_ message: AuthMessage) async throws {
+        guard let yourNonce = message.yourNonce else {
+            throw AuthError.malformedMessage("initialResponse missing yourNonce")
+        }
+        let nonceValid = try await AuthNonce.verify(yourNonce, wallet: wallet)
+        if !nonceValid {
+            throw AuthError.invalidNonce
+        }
+
+        guard var session = sessionManager.getSession(yourNonce) else {
+            throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
+        }
+
+        guard let peerInitial = message.initialNonce, let signature = message.signature else {
+            throw AuthError.malformedMessage("initialResponse missing initialNonce or signature")
+        }
+
+        let dataToVerify = decodedNonce(session.sessionNonce) + decodedNonce(peerInitial)
+        let verifyResult: Bool
+        do {
+            verifyResult = try await wallet.verifySignature(args: VerifySignatureArgs(
+                encryption: WalletEncryptionArgs(
+                    protocolID: Peer.signatureProtocol,
+                    keyID: "\(session.sessionNonce) \(peerInitial)",
+                    counterparty: .publicKey(message.identityKey)
+                ),
+                signature: signature,
+                data: dataToVerify
+            )).valid
+        } catch WalletError.invalidSignature {
+            throw AuthError.invalidSignature
+        }
+        if !verifyResult {
+            throw AuthError.invalidSignature
+        }
+
+        session.peerNonce = peerInitial
+        session.peerIdentityKey = message.identityKey
+        session.isAuthenticated = true
+        session.certificatesRequired = !certificatesToRequest.certifiers.isEmpty
+        session.certificatesValidated = !session.certificatesRequired
+        session.lastUpdate = Date()
+        sessionManager.updateSession(session)
+
+        lastInteractedPeer = message.identityKey
+
+        // Release the handshake waiter.
+        if let waiter = initialResponseWaiters.removeValue(forKey: session.sessionNonce) {
+            waiter.resume(returning: ())
+        }
+
+        // Honour any cert request the peer tacked onto the response.
+        if let requested = message.requestedCertificates, !requested.isEmpty {
+            for cb in certificatesRequestedListeners.values {
+                cb(message.identityKey, requested)
+            }
+        }
+    }
+
+    private func processCertificateRequest(_ message: AuthMessage) async throws {
+        guard let yourNonce = message.yourNonce else {
+            throw AuthError.malformedMessage("certificateRequest missing yourNonce")
+        }
+        let nonceValid = try await AuthNonce.verify(yourNonce, wallet: wallet)
+        if !nonceValid { throw AuthError.invalidNonce }
+
+        guard let session = sessionManager.getSession(yourNonce) else {
+            throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
+        }
+
+        guard let requested = message.requestedCertificates,
+              let signature = message.signature,
+              let peerNonce = message.nonce else {
+            throw AuthError.malformedMessage("certificateRequest missing fields")
+        }
+
+        // The signed data is the UTF-8 JSON of the requestedCertificates.
+        let jsonData = try JSONEncoder().encode(requested)
+        let valid = (try? await wallet.verifySignature(args: VerifySignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Peer.signatureProtocol,
+                keyID: "\(peerNonce) \(session.sessionNonce)",
+                counterparty: .publicKey(message.identityKey)
+            ),
+            signature: signature,
+            data: jsonData
+        )).valid) ?? false
+        if !valid { throw AuthError.invalidSignature }
+
+        for cb in certificatesRequestedListeners.values {
+            cb(message.identityKey, requested)
+        }
+    }
+
+    private func processCertificateResponse(_ message: AuthMessage) async throws {
+        guard let yourNonce = message.yourNonce else {
+            throw AuthError.malformedMessage("certificateResponse missing yourNonce")
+        }
+        let nonceValid = try await AuthNonce.verify(yourNonce, wallet: wallet)
+        if !nonceValid { throw AuthError.invalidNonce }
+
+        guard var session = sessionManager.getSession(yourNonce) else {
+            throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
+        }
+        guard let signature = message.signature, let peerNonce = message.nonce else {
+            throw AuthError.malformedMessage("certificateResponse missing fields")
+        }
+
+        // The signed data is the UTF-8 encoded JSON array of certificates.
+        let certs = message.certificates ?? []
+        let jsonData = try JSONEncoder().encode(certs.map { CertificateJSON(from: $0) })
+        let valid = (try? await wallet.verifySignature(args: VerifySignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Peer.signatureProtocol,
+                keyID: "\(peerNonce) \(session.sessionNonce)",
+                counterparty: .publicKey(message.identityKey)
+            ),
+            signature: signature,
+            data: jsonData
+        )).valid) ?? false
+        if !valid { throw AuthError.invalidSignature }
+
+        if !certs.isEmpty {
+            session.certificatesValidated = true
+            session.lastUpdate = Date()
+            sessionManager.updateSession(session)
+        }
+
+        let verifiableCerts = certs.map { VerifiableCertificate(certificate: $0, keyring: [:]) }
+        for cb in certificatesReceivedListeners.values {
+            cb(message.identityKey, verifiableCerts)
+        }
+    }
+
+    private func processGeneralMessage(_ message: AuthMessage) async throws {
+        guard let yourNonce = message.yourNonce else {
+            throw AuthError.malformedMessage("general message missing yourNonce")
+        }
+        let nonceValid = try await AuthNonce.verify(yourNonce, wallet: wallet)
+        if !nonceValid { throw AuthError.invalidNonce }
+
+        guard var session = sessionManager.getSession(yourNonce) else {
+            throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
+        }
+        guard let payload = message.payload,
+              let signature = message.signature,
+              let peerNonce = message.nonce else {
+            throw AuthError.malformedMessage("general message missing fields")
+        }
+
+        let valid = (try? await wallet.verifySignature(args: VerifySignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Peer.signatureProtocol,
+                keyID: "\(peerNonce) \(session.sessionNonce)",
+                counterparty: .publicKey(message.identityKey)
+            ),
+            signature: signature,
+            data: payload
+        )).valid) ?? false
+        if !valid { throw AuthError.invalidSignature }
+
+        session.lastUpdate = Date()
+        sessionManager.updateSession(session)
+        lastInteractedPeer = message.identityKey
+
+        for cb in generalMessageListeners.values {
+            cb(message.identityKey, payload)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func getIdentityKey() async throws -> PublicKey {
+        if let identityKey { return identityKey }
+        let result = try await wallet.getPublicKey(args: GetPublicKeyArgs(identityKey: true))
+        self.identityKey = result.publicKey
+        return result.publicKey
+    }
+
+    private func decodedNonce(_ base64: String) -> Data {
+        Data(base64Encoded: base64) ?? Data()
+    }
+
+    private func generateRandomBase64(byteCount: Int) throws -> String {
+        var bytes = Data(count: byteCount)
+        let status = bytes.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, byteCount, $0.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw AuthError.transportFailure("failed to generate random bytes")
+        }
+        return bytes.base64EncodedString()
+    }
+}
+
+// MARK: - JSON encoding helpers
+
+/// Thin wrapper used to give `Certificate` a deterministic JSON shape for
+/// signing. Matches the ts-sdk JSON representation used in
+/// `certificateRequest` / `certificateResponse`.
+private struct CertificateJSON: Codable {
+    let type: String
+    let serialNumber: String
+    let subject: String
+    let certifier: String
+    let revocationOutpoint: String
+    let fields: [String: String]
+    let signature: String?
+
+    init(from cert: Certificate) {
+        self.type = cert.type.base64EncodedString()
+        self.serialNumber = cert.serialNumber.base64EncodedString()
+        self.subject = cert.subject.hex
+        self.certifier = cert.certifier.hex
+        self.revocationOutpoint = cert.revocationOutpoint
+        self.fields = cert.fields
+        self.signature = cert.signature?.hex
+    }
+}

--- a/Sources/BSV/Auth/Peer.swift
+++ b/Sources/BSV/Auth/Peer.swift
@@ -417,8 +417,10 @@ public actor Peer {
             throw AuthError.malformedMessage("certificateRequest missing fields")
         }
 
-        // The signed data is the UTF-8 JSON of the requestedCertificates.
-        let jsonData = try JSONEncoder().encode(requested)
+        // The signed data is the canonical JSON of the requestedCertificates.
+        // See `CanonicalJSON.encodeRequestedCertificateSet` — both ends of
+        // the wire must agree on byte-for-byte identical pre-images.
+        let jsonData = try CanonicalJSON.encodeRequestedCertificateSet(requested)
         let valid = (try? await wallet.verifySignature(args: VerifySignatureArgs(
             encryption: WalletEncryptionArgs(
                 protocolID: Peer.signatureProtocol,
@@ -470,10 +472,10 @@ public actor Peer {
 
         // The signed data is the UTF-8 encoded JSON array of certificates.
         // Key ordering must be deterministic so both sides recompute the
-        // same pre-image — Swift's default JSONEncoder does not guarantee
-        // this, so we use `.sortedKeys`.
+        // same pre-image — see `CanonicalJSON.encodeCertificates` for the
+        // ts-sdk insertion-order layout.
         let certs = message.certificates ?? []
-        let jsonData = try Self.canonicalCertJSON(certs)
+        let jsonData = CanonicalJSON.encodeCertificates(certs)
         let valid = (try? await wallet.verifySignature(args: VerifySignatureArgs(
             encryption: WalletEncryptionArgs(
                 protocolID: Peer.signatureProtocol,
@@ -598,16 +600,6 @@ public actor Peer {
 
     // MARK: - Helpers
 
-    /// Canonicalise the JSON pre-image used for certificate-response
-    /// signing. Swift's default `JSONEncoder` does not guarantee key
-    /// ordering for `[String: String]` dictionaries or for arbitrary
-    /// structs, so both sides MUST sort keys to agree on the pre-image.
-    internal static func canonicalCertJSON(_ certs: [Certificate]) throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        return try encoder.encode(certs.map { CertificateJSON(from: $0) })
-    }
-
     private func getIdentityKey() async throws -> PublicKey {
         if let identityKey { return identityKey }
         let result = try await wallet.getPublicKey(args: GetPublicKeyArgs(identityKey: true))
@@ -631,27 +623,3 @@ public actor Peer {
     }
 }
 
-// MARK: - JSON encoding helpers
-
-/// Thin wrapper used to give `Certificate` a deterministic JSON shape for
-/// signing. Matches the ts-sdk JSON representation used in
-/// `certificateRequest` / `certificateResponse`.
-internal struct CertificateJSON: Codable {
-    let type: String
-    let serialNumber: String
-    let subject: String
-    let certifier: String
-    let revocationOutpoint: String
-    let fields: [String: String]
-    let signature: String?
-
-    init(from cert: Certificate) {
-        self.type = cert.type.base64EncodedString()
-        self.serialNumber = cert.serialNumber.base64EncodedString()
-        self.subject = cert.subject.hex
-        self.certifier = cert.certifier.hex
-        self.revocationOutpoint = cert.revocationOutpoint
-        self.fields = cert.fields
-        self.signature = cert.signature?.hex
-    }
-}

--- a/Sources/BSV/Auth/Peer.swift
+++ b/Sources/BSV/Auth/Peer.swift
@@ -379,8 +379,20 @@ public actor Peer {
         let nonceValid = try await AuthNonce.verify(yourNonce, wallet: wallet)
         if !nonceValid { throw AuthError.invalidNonce }
 
-        guard let session = sessionManager.getSession(yourNonce) else {
+        guard var session = sessionManager.getSession(yourNonce) else {
             throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
+        }
+
+        // Bind the signed message to the identity the session was
+        // established with. BRC-43 signature verification is
+        // ECDH-symmetric, so a peer who signed with counterparty=V using
+        // their own root key could otherwise pass verification regardless
+        // of what `message.identityKey` claims. We must therefore compare
+        // the claimed identity against the stored session identity AND
+        // verify using the stored identity rather than the claim.
+        guard let peerIdentityKey = session.peerIdentityKey,
+              message.identityKey == peerIdentityKey else {
+            throw AuthError.invalidSignature
         }
 
         guard let requested = message.requestedCertificates,
@@ -395,12 +407,23 @@ public actor Peer {
             encryption: WalletEncryptionArgs(
                 protocolID: Peer.signatureProtocol,
                 keyID: "\(peerNonce) \(session.sessionNonce)",
-                counterparty: .publicKey(message.identityKey)
+                counterparty: .publicKey(peerIdentityKey)
             ),
             signature: signature,
             data: jsonData
         )).valid) ?? false
         if !valid { throw AuthError.invalidSignature }
+
+        // A valid signed message proves the peer controls the claimed
+        // identity key. If this is the first cryptographic evidence we
+        // have (the responder path seats sessions with
+        // peerIdentityKeyVerified=false), promote the session so it's
+        // reachable via identity-key lookup.
+        if !session.peerIdentityKeyVerified {
+            session.peerIdentityKeyVerified = true
+            session.lastUpdate = Date()
+            sessionManager.updateSession(session)
+        }
 
         for cb in certificatesRequestedListeners.values {
             cb(message.identityKey, requested)
@@ -417,6 +440,14 @@ public actor Peer {
         guard var session = sessionManager.getSession(yourNonce) else {
             throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
         }
+
+        // Bind the signed envelope to the identity the session was
+        // established with — see the note in processCertificateRequest.
+        guard let peerIdentityKey = session.peerIdentityKey,
+              message.identityKey == peerIdentityKey else {
+            throw AuthError.invalidSignature
+        }
+
         guard let signature = message.signature, let peerNonce = message.nonce else {
             throw AuthError.malformedMessage("certificateResponse missing fields")
         }
@@ -431,12 +462,18 @@ public actor Peer {
             encryption: WalletEncryptionArgs(
                 protocolID: Peer.signatureProtocol,
                 keyID: "\(peerNonce) \(session.sessionNonce)",
-                counterparty: .publicKey(message.identityKey)
+                counterparty: .publicKey(peerIdentityKey)
             ),
             signature: signature,
             data: jsonData
         )).valid) ?? false
         if !valid { throw AuthError.invalidSignature }
+
+        // First valid signed message from the session peer — promote the
+        // session to verified so identity-key lookup can find it.
+        if !session.peerIdentityKeyVerified {
+            session.peerIdentityKeyVerified = true
+        }
 
         if !certs.isEmpty {
             // Verify each certificate individually. Every check uses the same
@@ -496,6 +533,20 @@ public actor Peer {
         guard var session = sessionManager.getSession(yourNonce) else {
             throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
         }
+
+        // Bind the signed envelope to the identity the session was
+        // established with. BRC-43 signature verification is
+        // ECDH-symmetric, so verifying with the attacker-controlled
+        // `message.identityKey` (a regression from the ts-sdk reference
+        // at Peer.ts:921) would allow any peer to pass verification by
+        // signing the payload with their own root key under
+        // counterparty=V. We must compare the claimed identity to the
+        // stored session identity AND verify using the stored identity.
+        guard let peerIdentityKey = session.peerIdentityKey,
+              message.identityKey == peerIdentityKey else {
+            throw AuthError.invalidSignature
+        }
+
         guard let payload = message.payload,
               let signature = message.signature,
               let peerNonce = message.nonce else {
@@ -506,19 +557,26 @@ public actor Peer {
             encryption: WalletEncryptionArgs(
                 protocolID: Peer.signatureProtocol,
                 keyID: "\(peerNonce) \(session.sessionNonce)",
-                counterparty: .publicKey(message.identityKey)
+                counterparty: .publicKey(peerIdentityKey)
             ),
             signature: signature,
             data: payload
         )).valid) ?? false
         if !valid { throw AuthError.invalidSignature }
 
+        // First valid signed message from the session peer — promote
+        // the session so identity-key lookup can find it. Before this
+        // point (responder path seeded from an unsigned initialRequest)
+        // the claimed identity was untrusted.
+        if !session.peerIdentityKeyVerified {
+            session.peerIdentityKeyVerified = true
+        }
         session.lastUpdate = Date()
         sessionManager.updateSession(session)
-        lastInteractedPeer = message.identityKey
+        lastInteractedPeer = peerIdentityKey
 
         for cb in generalMessageListeners.values {
-            cb(message.identityKey, payload)
+            cb(peerIdentityKey, payload)
         }
     }
 

--- a/Sources/BSV/Auth/Peer.swift
+++ b/Sources/BSV/Auth/Peer.swift
@@ -168,10 +168,15 @@ public actor Peer {
         let sessionNonce = try await AuthNonce.create(wallet: wallet)
         let certsRequired = !certificatesToRequest.certifiers.isEmpty
 
+        // We're about to initiate a handshake. `peerIdentityKey` here is
+        // the caller-supplied expected key — not yet verified. Leave
+        // `peerIdentityKeyVerified = false` until `processInitialResponse`
+        // verifies the peer's signature.
         sessionManager.addSession(PeerSession(
             isAuthenticated: false,
             sessionNonce: sessionNonce,
             peerIdentityKey: identityKey,
+            peerIdentityKeyVerified: false,
             certificatesRequired: certsRequired,
             certificatesValidated: !certsRequired
         ))
@@ -246,11 +251,21 @@ public actor Peer {
 
         let sessionNonce = try await AuthNonce.create(wallet: wallet)
         let certsRequired = !certificatesToRequest.certifiers.isEmpty
+        // BRC-66 `initialRequest` carries no signature, so the peer's
+        // claimed `identityKey` is an unverified claim at this point. We
+        // store it so we know what key to expect on the first signed
+        // message, but mark `peerIdentityKeyVerified = false` so
+        // `SessionManager` will not index the session under that identity.
+        // Otherwise an attacker could seed a session claiming any
+        // identity key and then have a later
+        // `getAuthenticatedSession(identityKey:)` call pick it up. See
+        // the BRC-66 security note on Vuln 2.
         sessionManager.addSession(PeerSession(
             isAuthenticated: true,
             sessionNonce: sessionNonce,
             peerNonce: initialNonce,
             peerIdentityKey: message.identityKey,
+            peerIdentityKeyVerified: false,
             certificatesRequired: certsRequired,
             certificatesValidated: !certsRequired
         ))
@@ -331,6 +346,11 @@ public actor Peer {
 
         session.peerNonce = peerInitial
         session.peerIdentityKey = message.identityKey
+        // On the initiator path we have just verified the peer's
+        // signature over the session-nonce pair, which proves control of
+        // `message.identityKey`. Mark the identity as verified so
+        // `SessionManager` indexes the session for identity-key lookup.
+        session.peerIdentityKeyVerified = true
         session.isAuthenticated = true
         session.certificatesRequired = !certificatesToRequest.certifiers.isEmpty
         session.certificatesValidated = !session.certificatesRequired

--- a/Sources/BSV/Auth/Peer.swift
+++ b/Sources/BSV/Auth/Peer.swift
@@ -309,66 +309,82 @@ public actor Peer {
     }
 
     private func processInitialResponse(_ message: AuthMessage) async throws {
-        guard let yourNonce = message.yourNonce else {
-            throw AuthError.malformedMessage("initialResponse missing yourNonce")
-        }
-        let nonceValid = try await AuthNonce.verify(yourNonce, wallet: wallet)
-        if !nonceValid {
-            throw AuthError.invalidNonce
-        }
-
-        guard var session = sessionManager.getSession(yourNonce) else {
-            throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
-        }
-
-        guard let peerInitial = message.initialNonce, let signature = message.signature else {
-            throw AuthError.malformedMessage("initialResponse missing initialNonce or signature")
-        }
-
-        let dataToVerify = decodedNonce(session.sessionNonce) + decodedNonce(peerInitial)
-        let verifyResult: Bool
+        // Track the session nonce we've matched the message to, so any
+        // throw below can unblock the handshake waiter instead of
+        // leaving `initiateHandshake` suspended on a continuation that
+        // will never be resumed. Without this, a malformed initialResponse
+        // (bad nonce, missing fields, bad signature, ...) causes the
+        // caller to hang forever.
+        var matchedSessionNonce: String?
         do {
-            verifyResult = try await wallet.verifySignature(args: VerifySignatureArgs(
-                encryption: WalletEncryptionArgs(
-                    protocolID: Peer.signatureProtocol,
-                    keyID: "\(session.sessionNonce) \(peerInitial)",
-                    counterparty: .publicKey(message.identityKey)
-                ),
-                signature: signature,
-                data: dataToVerify
-            )).valid
-        } catch WalletError.invalidSignature {
-            throw AuthError.invalidSignature
-        }
-        if !verifyResult {
-            throw AuthError.invalidSignature
-        }
-
-        session.peerNonce = peerInitial
-        session.peerIdentityKey = message.identityKey
-        // On the initiator path we have just verified the peer's
-        // signature over the session-nonce pair, which proves control of
-        // `message.identityKey`. Mark the identity as verified so
-        // `SessionManager` indexes the session for identity-key lookup.
-        session.peerIdentityKeyVerified = true
-        session.isAuthenticated = true
-        session.certificatesRequired = !certificatesToRequest.certifiers.isEmpty
-        session.certificatesValidated = !session.certificatesRequired
-        session.lastUpdate = Date()
-        sessionManager.updateSession(session)
-
-        lastInteractedPeer = message.identityKey
-
-        // Release the handshake waiter.
-        if let waiter = initialResponseWaiters.removeValue(forKey: session.sessionNonce) {
-            waiter.resume(returning: ())
-        }
-
-        // Honour any cert request the peer tacked onto the response.
-        if let requested = message.requestedCertificates, !requested.isEmpty {
-            for cb in certificatesRequestedListeners.values {
-                cb(message.identityKey, requested)
+            guard let yourNonce = message.yourNonce else {
+                throw AuthError.malformedMessage("initialResponse missing yourNonce")
             }
+            let nonceValid = try await AuthNonce.verify(yourNonce, wallet: wallet)
+            if !nonceValid {
+                throw AuthError.invalidNonce
+            }
+
+            guard var session = sessionManager.getSession(yourNonce) else {
+                throw AuthError.sessionNotFound("no session for nonce \(yourNonce)")
+            }
+            // From here on, any throw must wake the matching waiter.
+            matchedSessionNonce = session.sessionNonce
+
+            guard let peerInitial = message.initialNonce, let signature = message.signature else {
+                throw AuthError.malformedMessage("initialResponse missing initialNonce or signature")
+            }
+
+            let dataToVerify = decodedNonce(session.sessionNonce) + decodedNonce(peerInitial)
+            let verifyResult: Bool
+            do {
+                verifyResult = try await wallet.verifySignature(args: VerifySignatureArgs(
+                    encryption: WalletEncryptionArgs(
+                        protocolID: Peer.signatureProtocol,
+                        keyID: "\(session.sessionNonce) \(peerInitial)",
+                        counterparty: .publicKey(message.identityKey)
+                    ),
+                    signature: signature,
+                    data: dataToVerify
+                )).valid
+            } catch WalletError.invalidSignature {
+                throw AuthError.invalidSignature
+            }
+            if !verifyResult {
+                throw AuthError.invalidSignature
+            }
+
+            session.peerNonce = peerInitial
+            session.peerIdentityKey = message.identityKey
+            // On the initiator path we have just verified the peer's
+            // signature over the session-nonce pair, which proves control of
+            // `message.identityKey`. Mark the identity as verified so
+            // `SessionManager` indexes the session for identity-key lookup.
+            session.peerIdentityKeyVerified = true
+            session.isAuthenticated = true
+            session.certificatesRequired = !certificatesToRequest.certifiers.isEmpty
+            session.certificatesValidated = !session.certificatesRequired
+            session.lastUpdate = Date()
+            sessionManager.updateSession(session)
+
+            lastInteractedPeer = message.identityKey
+
+            // Release the handshake waiter.
+            if let waiter = initialResponseWaiters.removeValue(forKey: session.sessionNonce) {
+                waiter.resume(returning: ())
+            }
+
+            // Honour any cert request the peer tacked onto the response.
+            if let requested = message.requestedCertificates, !requested.isEmpty {
+                for cb in certificatesRequestedListeners.values {
+                    cb(message.identityKey, requested)
+                }
+            }
+        } catch {
+            if let sessionNonce = matchedSessionNonce {
+                failWaiter(sessionNonce: sessionNonce, error: error)
+            }
+            throw error
         }
     }
 

--- a/Sources/BSV/Auth/SessionManager.swift
+++ b/Sources/BSV/Auth/SessionManager.swift
@@ -86,7 +86,15 @@ public final class SessionManager: @unchecked Sendable {
 
         sessionsByNonce[session.sessionNonce] = session
 
-        if let identity = session.peerIdentityKey?.hex.lowercased() {
+        // Only index a session under its peer identity once we have
+        // cryptographic evidence the peer controls that key. Sessions
+        // created from an unsigned `initialRequest` carry only a
+        // self-asserted identity claim, and must therefore not be
+        // reachable via identity-key lookup — otherwise a later
+        // `getSession(<victim identity>)` could return an attacker-seeded
+        // session. See BRC-66 security note on Vuln 2.
+        if session.peerIdentityKeyVerified,
+           let identity = session.peerIdentityKey?.hex.lowercased() {
             nonceByIdentity[identity, default: []].insert(session.sessionNonce)
         }
     }

--- a/Sources/BSV/Auth/SessionManager.swift
+++ b/Sources/BSV/Auth/SessionManager.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Thread-safe BRC-66 session tracker.
+///
+/// Sessions are keyed by their unique `sessionNonce`, and a secondary index
+/// keeps track of which session(s) belong to a given `peerIdentityKey` so the
+/// lookup `getSession(:)` can accept either a nonce or an identity key.
+///
+/// Multiple simultaneous sessions per peer are allowed; `getSession(byIdentity:)`
+/// returns the most recently updated one.
+public final class SessionManager: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sessionsByNonce: [String: PeerSession] = [:]
+    private var nonceByIdentity: [String: Set<String>] = [:]
+
+    public init() {}
+
+    /// Insert or update a session, re-indexing the identity lookup if needed.
+    public func addSession(_ session: PeerSession) {
+        lock.lock()
+        defer { lock.unlock() }
+        upsertLocked(session)
+    }
+
+    /// Refresh an existing session. If no session exists with this nonce, it
+    /// is inserted (matching the ts-sdk behaviour).
+    public func updateSession(_ session: PeerSession) {
+        lock.lock()
+        defer { lock.unlock() }
+        upsertLocked(session)
+    }
+
+    /// Look up a session by nonce or by peer identity key (compressed hex).
+    ///
+    /// When `key` matches a stored `sessionNonce` the corresponding session
+    /// is returned. Otherwise the key is treated as a peer identity hex and
+    /// the most recently updated session for that peer is returned.
+    public func getSession(_ key: String) -> PeerSession? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let direct = sessionsByNonce[key] {
+            return direct
+        }
+        guard let nonces = nonceByIdentity[key.lowercased()] else { return nil }
+        var latest: PeerSession?
+        for nonce in nonces {
+            guard let candidate = sessionsByNonce[nonce] else { continue }
+            if latest == nil || candidate.lastUpdate > latest!.lastUpdate {
+                latest = candidate
+            }
+        }
+        return latest
+    }
+
+    /// Does a session exist for this nonce or identity key?
+    public func hasSession(_ key: String) -> Bool {
+        getSession(key) != nil
+    }
+
+    /// Remove a session and any associated identity-index entries.
+    public func removeSession(_ session: PeerSession) {
+        lock.lock()
+        defer { lock.unlock() }
+        sessionsByNonce.removeValue(forKey: session.sessionNonce)
+        if let identity = session.peerIdentityKey?.hex.lowercased() {
+            nonceByIdentity[identity]?.remove(session.sessionNonce)
+            if nonceByIdentity[identity]?.isEmpty == true {
+                nonceByIdentity.removeValue(forKey: identity)
+            }
+        }
+    }
+
+    // MARK: - Internal
+
+    private func upsertLocked(_ session: PeerSession) {
+        // Clear previous identity index for this nonce (in case the peer's
+        // identity changed during an upgrade from unauthenticated to
+        // authenticated).
+        if let existing = sessionsByNonce[session.sessionNonce],
+           let oldIdentity = existing.peerIdentityKey?.hex.lowercased() {
+            nonceByIdentity[oldIdentity]?.remove(session.sessionNonce)
+            if nonceByIdentity[oldIdentity]?.isEmpty == true {
+                nonceByIdentity.removeValue(forKey: oldIdentity)
+            }
+        }
+
+        sessionsByNonce[session.sessionNonce] = session
+
+        if let identity = session.peerIdentityKey?.hex.lowercased() {
+            nonceByIdentity[identity, default: []].insert(session.sessionNonce)
+        }
+    }
+}

--- a/Sources/BSV/Auth/certificates/Certificate.swift
+++ b/Sources/BSV/Auth/certificates/Certificate.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+/// A BRC-103 identity certificate.
+///
+/// Certificates are signed assertions made by a `certifier` about a
+/// `subject`, binding a set of named fields (any UTF-8 values) to a
+/// revocable on-chain outpoint. Verifiers can check the signature is valid
+/// and consult the revocation outpoint before trusting the fields.
+///
+/// Binary format (matches ts-sdk):
+/// ```
+/// type (32 bytes, raw)
+/// serialNumber (32 bytes, raw)
+/// subject (33 bytes, compressed pubkey)
+/// certifier (33 bytes, compressed pubkey)
+/// revocationOutpoint: TXID (32 bytes) || VarInt(outputIndex)
+/// VarInt(field count)
+/// for each field (sorted lexicographically):
+///   VarInt(name byte length) || name bytes
+///   VarInt(value byte length) || value bytes
+/// signature (DER, remainder of buffer) — optional
+/// ```
+public struct Certificate: Sendable, Equatable {
+    public var type: Data                // 32 bytes
+    public var serialNumber: Data        // 32 bytes
+    public var subject: PublicKey
+    public var certifier: PublicKey
+    public var revocationOutpoint: String // "<txid>.<vout>"
+    public var fields: [String: String]
+    public var signature: Data?
+
+    public init(
+        type: Data,
+        serialNumber: Data,
+        subject: PublicKey,
+        certifier: PublicKey,
+        revocationOutpoint: String,
+        fields: [String: String],
+        signature: Data? = nil
+    ) {
+        self.type = type
+        self.serialNumber = serialNumber
+        self.subject = subject
+        self.certifier = certifier
+        self.revocationOutpoint = revocationOutpoint
+        self.fields = fields
+        self.signature = signature
+    }
+
+    // MARK: - Serialisation
+
+    /// Serialise to the BRC-103 binary format.
+    public func toBinary(includeSignature: Bool = true) -> Data {
+        var out = Data()
+        out.append(type)
+        out.append(serialNumber)
+        out.append(subject.toCompressed())
+        out.append(certifier.toCompressed())
+
+        let parts = revocationOutpoint.split(separator: ".", maxSplits: 1).map(String.init)
+        let txidHex = parts.first ?? ""
+        let outputIndex = UInt64(parts.count > 1 ? parts[1] : "0") ?? 0
+        out.append(Data(hex: txidHex) ?? Data(count: 32))
+        out.append(VarInt.encode(outputIndex))
+
+        // Field list, sorted by name for deterministic hashing.
+        let sortedNames = fields.keys.sorted()
+        out.append(VarInt.encode(UInt64(sortedNames.count)))
+        for name in sortedNames {
+            let value = fields[name] ?? ""
+            let nameBytes = Data(name.utf8)
+            let valueBytes = Data(value.utf8)
+            out.append(VarInt.encode(UInt64(nameBytes.count)))
+            out.append(nameBytes)
+            out.append(VarInt.encode(UInt64(valueBytes.count)))
+            out.append(valueBytes)
+        }
+
+        if includeSignature, let sig = signature, !sig.isEmpty {
+            out.append(sig)
+        }
+        return out
+    }
+
+    /// Parse a certificate from its BRC-103 binary format.
+    public static func fromBinary(_ data: Data) -> Certificate? {
+        var reader = ByteReader(data)
+        guard let type = reader.read(32) else { return nil }
+        guard let serial = reader.read(32) else { return nil }
+        guard let subjectBytes = reader.read(33), let subject = PublicKey(data: subjectBytes) else { return nil }
+        guard let certifierBytes = reader.read(33), let certifier = PublicKey(data: certifierBytes) else { return nil }
+        guard let txid = reader.read(32) else { return nil }
+        guard let outputIndex = reader.readVarInt() else { return nil }
+        let revocation = "\(txid.hex).\(outputIndex)"
+
+        guard let nFields = reader.readVarInt() else { return nil }
+        var fields: [String: String] = [:]
+        for _ in 0..<nFields {
+            guard let nameLen = reader.readVarInt() else { return nil }
+            guard let nameBytes = reader.read(Int(nameLen)) else { return nil }
+            guard let valueLen = reader.readVarInt() else { return nil }
+            guard let valueBytes = reader.read(Int(valueLen)) else { return nil }
+            let name = String(data: nameBytes, encoding: .utf8) ?? ""
+            let value = String(data: valueBytes, encoding: .utf8) ?? ""
+            fields[name] = value
+        }
+
+        // Remaining bytes (if any) are the DER signature.
+        let signature = reader.remaining().isEmpty ? nil : reader.remaining()
+        return Certificate(
+            type: type,
+            serialNumber: serial,
+            subject: subject,
+            certifier: certifier,
+            revocationOutpoint: revocation,
+            fields: fields,
+            signature: signature
+        )
+    }
+
+    // MARK: - Signing / verifying
+
+    /// Key ID used to sign and verify the certificate. Uses base64 encodings
+    /// of `type` and `serialNumber` to match the ts-sdk convention.
+    internal var signatureKeyID: String {
+        "\(type.base64EncodedString()) \(serialNumber.base64EncodedString())"
+    }
+
+    internal static let signatureProtocol = WalletProtocol(
+        securityLevel: .counterparty,
+        protocol: "certificate signature"
+    )
+
+    /// Sign the certificate using the certifier wallet. This populates
+    /// `signature` and sets `certifier` to the wallet's identity key.
+    public mutating func sign(certifierWallet: WalletInterface) async throws {
+        guard signature == nil || signature?.isEmpty == true else {
+            throw AuthError.certificateInvalid("certificate is already signed")
+        }
+        let id = try await certifierWallet.getPublicKey(args: GetPublicKeyArgs(identityKey: true))
+        self.certifier = id.publicKey
+
+        let preimage = toBinary(includeSignature: false)
+        // ts-sdk omits `counterparty` on sign, which defaults to `anyone`.
+        // Pair that with `counterparty: certifier` on the anyone-side verify
+        // and BRC-42 key agreement recovers the same derived public key.
+        let result = try await certifierWallet.createSignature(args: CreateSignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Self.signatureProtocol,
+                keyID: signatureKeyID,
+                counterparty: .anyone
+            ),
+            data: preimage
+        ))
+        self.signature = result.signature
+    }
+
+    /// Verify the certifier's signature over the certificate body.
+    public func verify() async throws -> Bool {
+        guard let sig = signature, !sig.isEmpty else {
+            throw AuthError.certificateInvalid("certificate is not signed")
+        }
+        // Verification uses the "anyone" wallet (BRC-42 scalar-1 key) paired
+        // against the certifier identity key.
+        let verifier = ProtoWallet(keyDeriver: KeyDeriver.anyone)
+        let preimage = toBinary(includeSignature: false)
+        do {
+            let result = try await verifier.verifySignature(args: VerifySignatureArgs(
+                encryption: WalletEncryptionArgs(
+                    protocolID: Self.signatureProtocol,
+                    keyID: signatureKeyID,
+                    counterparty: .publicKey(certifier)
+                ),
+                signature: sig,
+                data: preimage
+            ))
+            return result.valid
+        } catch WalletError.invalidSignature {
+            return false
+        }
+    }
+}
+
+// MARK: - Small internal byte reader
+
+/// Minimal cursor-based reader used by certificate parsing. Lives here to
+/// keep Certificate self-contained; the wider SDK already has its own
+/// transaction reader, but that one is geared at big-integer bitcoin varints.
+struct ByteReader {
+    private let buffer: Data
+    private var cursor: Int
+
+    init(_ buffer: Data) {
+        self.buffer = buffer
+        self.cursor = 0
+    }
+
+    mutating func read(_ count: Int) -> Data? {
+        guard count >= 0, cursor + count <= buffer.count else { return nil }
+        let slice = buffer.subdata(in: (buffer.startIndex + cursor)..<(buffer.startIndex + cursor + count))
+        cursor += count
+        return slice
+    }
+
+    mutating func readVarInt() -> UInt64? {
+        guard let decoded = VarInt.decode(buffer, offset: cursor) else { return nil }
+        cursor += decoded.bytesRead
+        return decoded.value
+    }
+
+    func remaining() -> Data {
+        guard cursor < buffer.count else { return Data() }
+        return buffer.subdata(in: (buffer.startIndex + cursor)..<buffer.endIndex)
+    }
+}

--- a/Sources/BSV/Auth/certificates/Certificate.swift
+++ b/Sources/BSV/Auth/certificates/Certificate.swift
@@ -180,36 +180,3 @@ public struct Certificate: Sendable, Equatable {
         }
     }
 }
-
-// MARK: - Small internal byte reader
-
-/// Minimal cursor-based reader used by certificate parsing. Lives here to
-/// keep Certificate self-contained; the wider SDK already has its own
-/// transaction reader, but that one is geared at big-integer bitcoin varints.
-struct ByteReader {
-    private let buffer: Data
-    private var cursor: Int
-
-    init(_ buffer: Data) {
-        self.buffer = buffer
-        self.cursor = 0
-    }
-
-    mutating func read(_ count: Int) -> Data? {
-        guard count >= 0, cursor + count <= buffer.count else { return nil }
-        let slice = buffer.subdata(in: (buffer.startIndex + cursor)..<(buffer.startIndex + cursor + count))
-        cursor += count
-        return slice
-    }
-
-    mutating func readVarInt() -> UInt64? {
-        guard let decoded = VarInt.decode(buffer, offset: cursor) else { return nil }
-        cursor += decoded.bytesRead
-        return decoded.value
-    }
-
-    func remaining() -> Data {
-        guard cursor < buffer.count else { return Data() }
-        return buffer.subdata(in: (buffer.startIndex + cursor)..<buffer.endIndex)
-    }
-}

--- a/Sources/BSV/Auth/certificates/MasterCertificate.swift
+++ b/Sources/BSV/Auth/certificates/MasterCertificate.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+/// A BRC-103 master certificate.
+///
+/// Extends `Certificate` with a *master keyring*: for every field, the
+/// creating wallet stores an encrypted field-revelation key addressed to a
+/// counterparty (typically the subject or certifier). The subject can later
+/// decrypt the master keyring to recover field values, or re-encrypt a
+/// subset of the keys for a verifier to form a `VerifiableCertificate`.
+public struct MasterCertificate: Sendable {
+    public var certificate: Certificate
+    /// Field name → base64-encoded encrypted symmetric key for that field.
+    public var masterKeyring: [String: String]
+
+    public init(certificate: Certificate, masterKeyring: [String: String]) {
+        self.certificate = certificate
+        self.masterKeyring = masterKeyring
+    }
+
+    // MARK: - Field-level helpers
+
+    /// Protocol used for certificate-field encryption in the wallet layer.
+    internal static let fieldProtocol = WalletProtocol(
+        securityLevel: .counterparty,
+        protocol: "certificate field encryption"
+    )
+
+    /// For the MasterCertificate, the wallet keyID is just the field name.
+    /// For the VerifiableCertificate, the keyID is `"<serialNumberBase64> <fieldName>"`.
+    internal static func fieldKeyID(fieldName: String, serialNumber: Data? = nil) -> String {
+        if let serial = serialNumber {
+            return "\(serial.base64EncodedString()) \(fieldName)"
+        }
+        return fieldName
+    }
+
+    // MARK: - Creation
+
+    /// Encrypt a set of plaintext fields under random symmetric keys and
+    /// return the encrypted fields plus a master keyring.
+    ///
+    /// Mirrors ts-sdk `MasterCertificate.createCertificateFields`.
+    public static func createCertificateFields(
+        creatorWallet: WalletInterface,
+        certifierOrSubject: WalletCounterparty,
+        fields: [String: String]
+    ) async throws -> (certificateFields: [String: String], masterKeyring: [String: String]) {
+        var certificateFields: [String: String] = [:]
+        var masterKeyring: [String: String] = [:]
+
+        for (name, value) in fields {
+            let fieldKey = SymmetricKey.random()
+            let plaintext = Data(value.utf8)
+            let encryptedValue = try fieldKey.encrypt(plaintext)
+            certificateFields[name] = encryptedValue.base64EncodedString()
+
+            let encryptedKey = try await creatorWallet.encrypt(args: WalletEncryptArgs(
+                encryption: WalletEncryptionArgs(
+                    protocolID: fieldProtocol,
+                    keyID: fieldKeyID(fieldName: name),
+                    counterparty: certifierOrSubject
+                ),
+                plaintext: fieldKey.key
+            ))
+            masterKeyring[name] = encryptedKey.ciphertext.base64EncodedString()
+        }
+
+        return (certificateFields, masterKeyring)
+    }
+
+    /// Issue a full master certificate for a subject: encrypts the fields,
+    /// mints the master keyring, assembles a `Certificate`, and signs it.
+    public static func issueCertificateForSubject(
+        certifierWallet: WalletInterface,
+        subject: PublicKey,
+        fields: [String: String],
+        certificateType: Data,
+        serialNumber: Data? = nil,
+        revocationOutpoint: String = String(repeating: "0", count: 64) + ".0"
+    ) async throws -> MasterCertificate {
+        let serial: Data
+        if let serialNumber {
+            serial = serialNumber
+        } else {
+            var bytes = Data(count: 32)
+            let status = bytes.withUnsafeMutableBytes {
+                SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
+            }
+            guard status == errSecSuccess else {
+                throw AuthError.certificateInvalid("failed to generate serial number")
+            }
+            serial = bytes
+        }
+
+        let (encryptedFields, masterKeyring) = try await createCertificateFields(
+            creatorWallet: certifierWallet,
+            certifierOrSubject: .publicKey(subject),
+            fields: fields
+        )
+
+        let certifierID = try await certifierWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        var cert = Certificate(
+            type: certificateType,
+            serialNumber: serial,
+            subject: subject,
+            certifier: certifierID,
+            revocationOutpoint: revocationOutpoint,
+            fields: encryptedFields,
+            signature: nil
+        )
+        try await cert.sign(certifierWallet: certifierWallet)
+
+        return MasterCertificate(certificate: cert, masterKeyring: masterKeyring)
+    }
+
+    // MARK: - Decrypting / keyring transformation
+
+    /// Decrypt a single master-keyring entry, returning the symmetric key
+    /// and the decrypted field value.
+    public static func decryptField(
+        subjectOrCertifierWallet: WalletInterface,
+        masterKeyring: [String: String],
+        fieldName: String,
+        encryptedFieldValue: String,
+        counterparty: WalletCounterparty
+    ) async throws -> (fieldKey: SymmetricKey, value: String) {
+        guard let encKey = masterKeyring[fieldName],
+              let encKeyData = Data(base64Encoded: encKey) else {
+            throw AuthError.certificateInvalid("missing master keyring entry for \(fieldName)")
+        }
+
+        let decryptedKey = try await subjectOrCertifierWallet.decrypt(args: WalletDecryptArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: fieldProtocol,
+                keyID: fieldKeyID(fieldName: fieldName),
+                counterparty: counterparty
+            ),
+            ciphertext: encKeyData
+        )).plaintext
+
+        guard let symKey = SymmetricKey(key: decryptedKey) else {
+            throw AuthError.certificateInvalid("master keyring contained invalid key material")
+        }
+
+        guard let encValData = Data(base64Encoded: encryptedFieldValue) else {
+            throw AuthError.certificateInvalid("field value is not valid base64")
+        }
+        let plaintext = try symKey.decrypt(encValData)
+        return (symKey, String(data: plaintext, encoding: .utf8) ?? "")
+    }
+
+    /// Re-encrypt a subset of master keys for a verifier to produce a
+    /// verifier-specific keyring suitable for a `VerifiableCertificate`.
+    public static func createKeyringForVerifier(
+        subjectWallet: WalletInterface,
+        certifier: WalletCounterparty,
+        verifier: WalletCounterparty,
+        fields: [String: String],
+        fieldsToReveal: [String],
+        masterKeyring: [String: String],
+        serialNumber: Data
+    ) async throws -> [String: String] {
+        var revelation: [String: String] = [:]
+        for fieldName in fieldsToReveal {
+            guard let encryptedFieldValue = fields[fieldName] else {
+                throw AuthError.certificateInvalid("field \(fieldName) is not in the certificate")
+            }
+
+            let (fieldKey, _) = try await decryptField(
+                subjectOrCertifierWallet: subjectWallet,
+                masterKeyring: masterKeyring,
+                fieldName: fieldName,
+                encryptedFieldValue: encryptedFieldValue,
+                counterparty: certifier
+            )
+
+            let encryptedForVerifier = try await subjectWallet.encrypt(args: WalletEncryptArgs(
+                encryption: WalletEncryptionArgs(
+                    protocolID: fieldProtocol,
+                    keyID: fieldKeyID(fieldName: fieldName, serialNumber: serialNumber),
+                    counterparty: verifier
+                ),
+                plaintext: fieldKey.key
+            ))
+            revelation[fieldName] = encryptedForVerifier.ciphertext.base64EncodedString()
+        }
+        return revelation
+    }
+}

--- a/Sources/BSV/Auth/certificates/VerifiableCertificate.swift
+++ b/Sources/BSV/Auth/certificates/VerifiableCertificate.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// A BRC-103 verifiable certificate.
+///
+/// A `VerifiableCertificate` pairs a signed `Certificate` with a
+/// verifier-specific keyring that enables selective disclosure: for each
+/// field the verifier is allowed to see, the keyring contains the field
+/// revelation key re-encrypted for the verifier.
+public struct VerifiableCertificate: Sendable {
+    public var certificate: Certificate
+    /// Field name → base64-encoded encrypted field revelation key.
+    public var keyring: [String: String]
+    /// Lazily populated cache of decrypted field values (plaintext UTF-8).
+    public private(set) var decryptedFields: [String: String]?
+
+    public init(
+        certificate: Certificate,
+        keyring: [String: String],
+        decryptedFields: [String: String]? = nil
+    ) {
+        self.certificate = certificate
+        self.keyring = keyring
+        self.decryptedFields = decryptedFields
+    }
+
+    // MARK: - Decryption
+
+    /// Decrypt every field listed in the keyring using the verifier's wallet.
+    ///
+    /// The verifier wallet must be able to decrypt the keyring entries
+    /// (which were encrypted against the verifier's identity key by the
+    /// subject), and then each resulting symmetric key is used to unwrap the
+    /// corresponding field value.
+    @discardableResult
+    public mutating func decryptFields(verifierWallet: WalletInterface) async throws -> [String: String] {
+        guard !keyring.isEmpty else {
+            throw AuthError.certificateInvalid("verifiable certificate has no keyring")
+        }
+
+        var decrypted: [String: String] = [:]
+        for (fieldName, encryptedKey) in keyring {
+            guard let encKeyData = Data(base64Encoded: encryptedKey) else {
+                throw AuthError.certificateInvalid("keyring entry for \(fieldName) is not base64")
+            }
+
+            let keyBytes = try await verifierWallet.decrypt(args: WalletDecryptArgs(
+                encryption: WalletEncryptionArgs(
+                    protocolID: MasterCertificate.fieldProtocol,
+                    keyID: MasterCertificate.fieldKeyID(
+                        fieldName: fieldName,
+                        serialNumber: certificate.serialNumber
+                    ),
+                    counterparty: .publicKey(certificate.subject)
+                ),
+                ciphertext: encKeyData
+            )).plaintext
+
+            guard let symKey = SymmetricKey(key: keyBytes) else {
+                throw AuthError.certificateInvalid("invalid field revelation key for \(fieldName)")
+            }
+
+            guard let encField = certificate.fields[fieldName],
+                  let encFieldData = Data(base64Encoded: encField) else {
+                throw AuthError.certificateInvalid("encrypted field value for \(fieldName) is missing or malformed")
+            }
+
+            let plain = try symKey.decrypt(encFieldData)
+            decrypted[fieldName] = String(data: plain, encoding: .utf8) ?? ""
+        }
+
+        self.decryptedFields = decrypted
+        return decrypted
+    }
+}

--- a/Sources/BSV/Auth/transports/SimplifiedFetchTransport.swift
+++ b/Sources/BSV/Auth/transports/SimplifiedFetchTransport.swift
@@ -1,0 +1,182 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// A HTTP `Transport` that POSTs serialised `AuthMessage`s to a remote peer.
+///
+/// Handshake-time messages (`initialRequest`, `initialResponse`,
+/// `certificateRequest`, `certificateResponse`) are posted to
+/// `<baseURL>/.well-known/auth` as JSON. This matches the ts-sdk
+/// `SimplifiedFetchTransport` wire format for non-general messages.
+///
+/// Note: this Swift implementation currently focuses on the non-general
+/// handshake path used by `Peer` end-to-end tests. The full
+/// header-tunnelled `general` message mode (which re-packages the HTTP
+/// request as the signed payload) is not yet supported — users who need it
+/// should implement a custom `Transport` until parity is added.
+public final class SimplifiedFetchTransport: Transport, @unchecked Sendable {
+    public let baseURL: URL
+    public let session: URLSession
+    private let lock = NSLock()
+    private var onDataCallback: (@Sendable (AuthMessage) async throws -> Void)?
+
+    public init(baseURL: URL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    // MARK: - Transport conformance
+
+    public func send(_ message: AuthMessage) async throws {
+        if message.messageType == .general {
+            throw AuthError.transportFailure(
+                "SimplifiedFetchTransport: general message tunnelling is not yet supported"
+            )
+        }
+
+        let body = try SimplifiedFetchTransport.encodeAuthMessage(message)
+        var request = URLRequest(url: baseURL.appendingPathComponent(".well-known/auth"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = body
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw AuthError.transportFailure("non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw AuthError.transportFailure("HTTP \(http.statusCode) from \(baseURL)")
+        }
+
+        if data.isEmpty { return }
+
+        let inbound = try SimplifiedFetchTransport.decodeAuthMessage(data)
+        let cb = lock.withLock { onDataCallback }
+        if let cb { try await cb(inbound) }
+    }
+
+    public func onData(_ callback: @escaping @Sendable (AuthMessage) async throws -> Void) async throws {
+        lock.withLock { self.onDataCallback = callback }
+    }
+
+    // MARK: - Wire format
+
+    /// Encode an `AuthMessage` to JSON matching the ts-sdk shape.
+    static func encodeAuthMessage(_ message: AuthMessage) throws -> Data {
+        var body: [String: Any] = [
+            "version": message.version,
+            "messageType": message.messageType.rawValue,
+            "identityKey": message.identityKey.hex
+        ]
+        if let n = message.nonce { body["nonce"] = n }
+        if let i = message.initialNonce { body["initialNonce"] = i }
+        if let y = message.yourNonce { body["yourNonce"] = y }
+        if let payload = message.payload { body["payload"] = Array(payload) }
+        if let signature = message.signature { body["signature"] = Array(signature) }
+        if let reqs = message.requestedCertificates {
+            body["requestedCertificates"] = [
+                "certifiers": reqs.certifiers,
+                "types": reqs.types
+            ]
+        }
+        if let certs = message.certificates {
+            body["certificates"] = certs.map { encodeCertificate($0) }
+        }
+        return try JSONSerialization.data(withJSONObject: body, options: [])
+    }
+
+    static func encodeCertificate(_ cert: Certificate) -> [String: Any] {
+        var dict: [String: Any] = [
+            "type": cert.type.base64EncodedString(),
+            "serialNumber": cert.serialNumber.base64EncodedString(),
+            "subject": cert.subject.hex,
+            "certifier": cert.certifier.hex,
+            "revocationOutpoint": cert.revocationOutpoint,
+            "fields": cert.fields
+        ]
+        if let sig = cert.signature { dict["signature"] = sig.hex }
+        return dict
+    }
+
+    /// Decode a single `AuthMessage` from a JSON body.
+    static func decodeAuthMessage(_ data: Data) throws -> AuthMessage {
+        guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AuthError.malformedMessage("body is not a JSON object")
+        }
+        let version = obj["version"] as? String ?? AUTH_VERSION
+        guard let typeRaw = obj["messageType"] as? String,
+              let type = AuthMessageType(rawValue: typeRaw) else {
+            throw AuthError.malformedMessage("missing or invalid messageType")
+        }
+        guard let idHex = obj["identityKey"] as? String,
+              let identity = PublicKey(hex: idHex) else {
+            throw AuthError.malformedMessage("missing or invalid identityKey")
+        }
+
+        var message = AuthMessage(version: version, messageType: type, identityKey: identity)
+        message.nonce = obj["nonce"] as? String
+        message.initialNonce = obj["initialNonce"] as? String
+        message.yourNonce = obj["yourNonce"] as? String
+        if let payload = decodeByteArray(obj["payload"]) { message.payload = payload }
+        if let signature = decodeByteArray(obj["signature"]) { message.signature = signature }
+        if let reqs = obj["requestedCertificates"] as? [String: Any] {
+            let certifiers = reqs["certifiers"] as? [String] ?? []
+            let types = reqs["types"] as? [String: [String]] ?? [:]
+            message.requestedCertificates = RequestedCertificateSet(certifiers: certifiers, types: types)
+        }
+        if let certs = obj["certificates"] as? [[String: Any]] {
+            message.certificates = certs.compactMap(decodeCertificate)
+        }
+        return message
+    }
+
+    static func decodeCertificate(_ obj: [String: Any]) -> Certificate? {
+        guard
+            let typeStr = obj["type"] as? String,
+            let type = Data(base64Encoded: typeStr),
+            let serialStr = obj["serialNumber"] as? String,
+            let serial = Data(base64Encoded: serialStr),
+            let subjectHex = obj["subject"] as? String,
+            let subject = PublicKey(hex: subjectHex),
+            let certifierHex = obj["certifier"] as? String,
+            let certifier = PublicKey(hex: certifierHex),
+            let revocation = obj["revocationOutpoint"] as? String,
+            let fields = obj["fields"] as? [String: String]
+        else { return nil }
+        let signature = (obj["signature"] as? String).flatMap { Data(hex: $0) }
+        return Certificate(
+            type: type,
+            serialNumber: serial,
+            subject: subject,
+            certifier: certifier,
+            revocationOutpoint: revocation,
+            fields: fields,
+            signature: signature
+        )
+    }
+
+    static func decodeByteArray(_ value: Any?) -> Data? {
+        if let ints = value as? [Int] {
+            return Data(ints.map { UInt8(truncatingIfNeeded: $0) })
+        }
+        if let numbers = value as? [NSNumber] {
+            return Data(numbers.map { UInt8(truncatingIfNeeded: $0.intValue) })
+        }
+        if let hex = value as? String {
+            return Data(hex: hex)
+        }
+        return nil
+    }
+}
+
+// MARK: - NSLock convenience
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
+    }
+}

--- a/Sources/BSV/Overlay/Historian.swift
+++ b/Sources/BSV/Overlay/Historian.swift
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Historian: build a chronological history of interpreted output values by
+// traversing the input ancestry of a starting transaction.
+//
+// Ported from ts-sdk src/overlay-tools/Historian.ts. An interpreter maps
+// `(tx, outputIndex) -> T?` and controls what counts as "history". The
+// traversal is cycle-safe, order is oldest-first, and optional caching
+// deduplicates repeated queries across the same interpreter version and
+// context key.
+
+import Foundation
+
+/// Function shape used by `Historian`: decodes a single output into a
+/// domain value, or returns `nil` if the output does not contribute to
+/// history.
+///
+/// - Parameters:
+///   - tx: The transaction containing the output.
+///   - outputIndex: Index of the output within `tx.outputs`.
+///   - context: Optional caller-supplied context.
+/// - Returns: The interpreted domain value, or `nil` if the output is
+///   not relevant for this interpreter/context.
+public typealias HistorianInterpreter<T, C> = (
+    _ tx: Transaction,
+    _ outputIndex: Int,
+    _ context: C?
+) async throws -> T?
+
+/// Key derivation strategy used when caching Historian results.
+public typealias HistorianContextKey<C> = (C?) -> String
+
+/// Historian traverses a transaction's input ancestry to build a
+/// chronological history of interpreted values.
+///
+/// `Historian` is not an actor: `Transaction` is a class and therefore not
+/// `Sendable`, so the traversal and interpreter both run on the caller's
+/// isolation domain. The optional cache is layered on top as an `actor`.
+public struct Historian<T: Sendable, C> {
+    private let interpreter: HistorianInterpreter<T, C>
+    private let contextKeyFn: HistorianContextKey<C>
+    private let interpreterVersion: String
+    private let cache: HistorianCache<T>?
+
+    /// Create a new historian.
+    ///
+    /// - Parameters:
+    ///   - interpreter: Function that decodes a single output.
+    ///   - interpreterVersion: Bump this when interpreter semantics change to
+    ///     invalidate any cached entries keyed by the old version.
+    ///   - enableCache: When `true`, builds an in-memory cache keyed by
+    ///     `interpreterVersion|txid|contextKey`.
+    ///   - contextKeyFn: Optional closure that maps a context to a stable
+    ///     cache-key fragment. Defaults to `"nil"` or `"ctx:\(value)"`.
+    public init(
+        interpreter: @escaping HistorianInterpreter<T, C>,
+        interpreterVersion: String = "v1",
+        enableCache: Bool = false,
+        contextKeyFn: HistorianContextKey<C>? = nil
+    ) {
+        self.interpreter = interpreter
+        self.interpreterVersion = interpreterVersion
+        self.cache = enableCache ? HistorianCache() : nil
+        self.contextKeyFn = contextKeyFn ?? { context in
+            guard let context else { return "nil" }
+            return "ctx:\(String(describing: context))"
+        }
+    }
+
+    /// Build a chronological history of interpreted values.
+    ///
+    /// The traversal starts at `startTransaction`, walks
+    /// `inputs[].sourceTransaction` recursively, and collects interpreted
+    /// values. Each transaction is visited at most once. Results are
+    /// returned oldest-first.
+    public func buildHistory(
+        startTransaction: Transaction,
+        context: C? = nil
+    ) async throws -> [T] {
+        let key = cacheKey(for: startTransaction, context: context)
+        if let cache, let cached = await cache.get(key) {
+            return cached
+        }
+
+        var history: [T] = []
+        var visited = Set<String>()
+        try await traverse(
+            transaction: startTransaction,
+            context: context,
+            visited: &visited,
+            history: &history
+        )
+        // Traversal appends in reverse chronological order, so reverse it.
+        let chronological = Array(history.reversed())
+
+        if let cache {
+            await cache.set(key, chronological)
+        }
+        return chronological
+    }
+
+    // MARK: - Private helpers
+
+    private func cacheKey(for tx: Transaction, context: C?) -> String {
+        "\(interpreterVersion)|\(tx.txid())|\(contextKeyFn(context))"
+    }
+
+    private func traverse(
+        transaction: Transaction,
+        context: C?,
+        visited: inout Set<String>,
+        history: inout [T]
+    ) async throws {
+        let txid = transaction.txid()
+        if visited.contains(txid) { return }
+        visited.insert(txid)
+
+        for index in 0..<transaction.outputs.count {
+            do {
+                if let value = try await interpreter(transaction, index, context) {
+                    history.append(value)
+                }
+            } catch {
+                // Swallow interpreter errors — they just mean the output is
+                // not relevant for this history.
+            }
+        }
+
+        for input in transaction.inputs {
+            if let parent = input.sourceTransaction {
+                try await traverse(
+                    transaction: parent,
+                    context: context,
+                    visited: &visited,
+                    history: &history
+                )
+            }
+        }
+    }
+}
+
+/// A tiny actor-backed cache used by `Historian` when caching is enabled.
+///
+/// This is not exposed outside the overlay module; callers that want
+/// externally-visible caching should wrap their own storage.
+final actor HistorianCache<T: Sendable> {
+    private var storage: [String: [T]] = [:]
+
+    func get(_ key: String) -> [T]? { storage[key] }
+    func set(_ key: String, _ value: [T]) { storage[key] = value }
+}

--- a/Sources/BSV/Overlay/HostReputationTracker.swift
+++ b/Sources/BSV/Overlay/HostReputationTracker.swift
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Per-host latency/failure scoring used to prefer reliable overlay hosts.
+//
+// Ported from ts-sdk src/overlay-tools/HostReputationTracker.ts. The
+// behaviour matches the TypeScript implementation:
+//
+//   - Latency is smoothed with an EMA (factor 0.25).
+//   - Failures accumulate a per-host back-off penalty with exponential growth
+//     up to a maximum, before applying a fixed per-failure penalty.
+//   - Score is computed as `latency + failurePenalty + backoffPenalty -
+//     successBonus`, where the success bonus is capped so that a host with
+//     zero latency is never rewarded below zero.
+//
+// The tracker is an `actor` so it can be freely shared between asynchronous
+// overlay operations without additional locking.
+
+import Foundation
+
+/// Snapshot of the statistics held for a single overlay host.
+public struct HostReputationStats: Sendable, Equatable {
+    /// The smoothed latency in milliseconds.
+    public var smoothedLatencyMs: Double
+    /// Consecutive failure count since the last success.
+    public var consecutiveFailures: Int
+    /// Timestamp when the next request may be attempted.
+    public var backoffUntil: Date?
+    /// Total successful requests ever recorded.
+    public var totalSuccesses: Int
+
+    public init(
+        smoothedLatencyMs: Double = HostReputationTracker.defaultLatencyMs,
+        consecutiveFailures: Int = 0,
+        backoffUntil: Date? = nil,
+        totalSuccesses: Int = 0
+    ) {
+        self.smoothedLatencyMs = smoothedLatencyMs
+        self.consecutiveFailures = consecutiveFailures
+        self.backoffUntil = backoffUntil
+        self.totalSuccesses = totalSuccesses
+    }
+}
+
+/// Tracks per-host latency, failures, and back-off to rank overlay hosts
+/// by relative desirability.
+public actor HostReputationTracker {
+    /// Default assumed latency for unknown hosts (ms).
+    public static let defaultLatencyMs: Double = 1500
+    /// EMA smoothing factor applied to new latency samples.
+    public static let latencySmoothingFactor: Double = 0.25
+    /// Base back-off delay applied after the grace period (ms).
+    public static let baseBackoffMs: Double = 1000
+    /// Maximum back-off delay (ms).
+    public static let maxBackoffMs: Double = 60_000
+    /// Constant penalty added per consecutive failure when scoring.
+    public static let failurePenaltyMs: Double = 400
+    /// Per-success bonus subtracted from a host's score.
+    public static let successBonusMs: Double = 30
+    /// Grace period (in consecutive failures) before back-off starts.
+    public static let failureBackoffGrace: Int = 2
+
+    /// In-memory reputation store keyed by host URL.
+    private var stats: [String: HostReputationStats] = [:]
+
+    public init() {}
+
+    /// Replace the tracked stats for a host (primarily for test fixtures).
+    public func seed(host: String, stats: HostReputationStats) {
+        self.stats[host] = stats
+    }
+
+    /// Look up the current snapshot for a host.
+    public func snapshot(for host: String) -> HostReputationStats {
+        stats[host] ?? HostReputationStats()
+    }
+
+    /// Record a successful response from `host` that took `latencyMs` to
+    /// complete. The latency is folded into the EMA, consecutive failures
+    /// are reset, and total successes is incremented.
+    public func recordSuccess(host: String, latencyMs: Double) {
+        var entry = stats[host] ?? HostReputationStats()
+        let sample = max(latencyMs, 0)
+        let alpha = Self.latencySmoothingFactor
+        let previous = entry.smoothedLatencyMs
+        entry.smoothedLatencyMs = previous == Self.defaultLatencyMs && entry.totalSuccesses == 0
+            ? sample
+            : previous + alpha * (sample - previous)
+        entry.consecutiveFailures = 0
+        entry.backoffUntil = nil
+        entry.totalSuccesses += 1
+        stats[host] = entry
+    }
+
+    /// Record a failure against `host`. Consecutive failures past the
+    /// grace period accrue exponential back-off capped at `maxBackoffMs`.
+    ///
+    /// - Parameter immediate: Set to `true` for DNS/fetch-level failures
+    ///   which should bypass the grace window entirely.
+    public func recordFailure(host: String, immediate: Bool = false) {
+        var entry = stats[host] ?? HostReputationStats()
+        if immediate {
+            entry.consecutiveFailures = max(entry.consecutiveFailures, Self.failureBackoffGrace) + 1
+        } else {
+            entry.consecutiveFailures += 1
+        }
+        if entry.consecutiveFailures > Self.failureBackoffGrace {
+            let steps = entry.consecutiveFailures - Self.failureBackoffGrace
+            let exponent = max(steps - 1, 0)
+            let raw = Self.baseBackoffMs * pow(2.0, Double(exponent))
+            let backoffMs = min(raw, Self.maxBackoffMs)
+            entry.backoffUntil = Date().addingTimeInterval(backoffMs / 1000)
+        }
+        stats[host] = entry
+    }
+
+    /// Whether a host is currently inside its back-off window.
+    public func isInBackoff(host: String, now: Date = Date()) -> Bool {
+        guard let until = stats[host]?.backoffUntil else { return false }
+        return until > now
+    }
+
+    /// Numeric score where lower is better. Used to rank hosts.
+    public func computeScore(for host: String, now: Date = Date()) -> Double {
+        let entry = stats[host] ?? HostReputationStats()
+        let backoffRemaining = entry.backoffUntil.map { max($0.timeIntervalSince(now) * 1000, 0) } ?? 0
+        let failurePenalty = Double(entry.consecutiveFailures) * Self.failurePenaltyMs
+        let bonusCap = entry.smoothedLatencyMs / 2
+        let bonus = min(Double(entry.totalSuccesses) * Self.successBonusMs, bonusCap)
+        return entry.smoothedLatencyMs + failurePenalty + backoffRemaining - bonus
+    }
+
+    /// Return a copy of `hosts` sorted from best to worst by score.
+    public func rank(hosts: [String], now: Date = Date()) -> [String] {
+        var scored: [(String, Double)] = []
+        for host in hosts {
+            scored.append((host, computeScore(for: host, now: now)))
+        }
+        scored.sort { lhs, rhs in
+            if lhs.1 == rhs.1 { return lhs.0 < rhs.0 }
+            return lhs.1 < rhs.1
+        }
+        return scored.map { $0.0 }
+    }
+}

--- a/Sources/BSV/Overlay/LookupResolver.swift
+++ b/Sources/BSV/Overlay/LookupResolver.swift
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Overlay lookup resolver.
+//
+// Ported from ts-sdk src/overlay-tools/LookupResolver.ts. The resolver
+// takes a `LookupQuestion`, discovers overlay hosts that host the named
+// lookup service, queries a subset of them in parallel, and merges
+// responses — preferring the first response and then waiting a short
+// grace window for additional answers.
+
+import Foundation
+
+/// Resolves overlay hosts that host a given lookup service.
+public protocol LookupHostResolver: Sendable {
+    /// Return the overlay hosts that currently host `service`.
+    func hosts(forService service: String) async throws -> [String]
+}
+
+/// Default SLAP trackers used on mainnet, matching the ts-sdk defaults.
+public enum OverlayDefaultTrackers {
+    public static let mainnetSLAPTrackers: [String] = [
+        "https://overlay-us-1.bsvb.tech",
+        "https://overlay-eu-1.bsvb.tech",
+        "https://overlay-ap-1.bsvb.tech",
+        "https://users.bapp.dev"
+    ]
+    public static let testnetSLAPTrackers: [String] = [
+        "https://testnet-overlay-us-1.bsvb.tech",
+        "https://testnet-overlay-eu-1.bsvb.tech",
+        "https://testnet-users.bapp.dev"
+    ]
+}
+
+/// Configuration for a `LookupResolver`.
+public struct LookupResolverConfig: Sendable {
+    /// Network preset used when picking the default SLAP trackers.
+    public var networkPreset: OverlayNetworkPreset
+    /// Override the SLAP trackers used to discover hosts.
+    public var slapTrackers: [String]?
+    /// Per-host request timeout in seconds.
+    public var timeout: TimeInterval
+    /// Extra time (in seconds) to wait after the first response before
+    /// returning a merged answer.
+    public var graceWindow: TimeInterval
+    /// Maximum number of hosts queried in parallel.
+    public var maxParallelQueries: Int
+
+    public init(
+        networkPreset: OverlayNetworkPreset = .mainnet,
+        slapTrackers: [String]? = nil,
+        timeout: TimeInterval = 10,
+        graceWindow: TimeInterval = 0.08,
+        maxParallelQueries: Int = 5
+    ) {
+        self.networkPreset = networkPreset
+        self.slapTrackers = slapTrackers
+        self.timeout = timeout
+        self.graceWindow = graceWindow
+        self.maxParallelQueries = maxParallelQueries
+    }
+}
+
+/// Lookup resolver that queries overlay hosts for a `LookupQuestion`.
+public struct LookupResolver: Sendable {
+    public let hostResolver: LookupHostResolver
+    public let facilitator: OverlayLookupFacilitator
+    public let reputation: HostReputationTracker
+    public let config: LookupResolverConfig
+
+    public init(
+        hostResolver: LookupHostResolver,
+        facilitator: OverlayLookupFacilitator = HTTPSOverlayLookupFacilitator(),
+        reputation: HostReputationTracker = HostReputationTracker(),
+        config: LookupResolverConfig = LookupResolverConfig()
+    ) {
+        self.hostResolver = hostResolver
+        self.facilitator = facilitator
+        self.reputation = reputation
+        self.config = config
+    }
+
+    /// Query overlay hosts for `question`.
+    ///
+    /// Validates the `ls_` prefix, resolves hosts, ranks them via the
+    /// reputation tracker, then queries the top `maxParallelQueries` hosts
+    /// in parallel. The first response starts a grace window during which
+    /// additional responses may also be merged into the result. Outputs
+    /// are deduplicated by `txid.outputIndex`.
+    public func query(_ question: LookupQuestion) async throws -> LookupAnswer {
+        guard question.service.hasPrefix("ls_") else {
+            throw OverlayError.invalidServiceName(question.service)
+        }
+
+        let hosts = try await hostResolver.hosts(forService: question.service)
+        var filtered: [String] = []
+        for host in hosts where !(await reputation.isInBackoff(host: host)) {
+            filtered.append(host)
+        }
+        if filtered.isEmpty {
+            throw OverlayError.noHostsInterested("no hosts for service \(question.service)")
+        }
+        let ranked = await reputation.rank(hosts: filtered)
+        let selected = Array(ranked.prefix(config.maxParallelQueries))
+
+        let answers = try await gatherAnswers(hosts: selected, question: question)
+        return mergeAnswers(answers)
+    }
+
+    // MARK: - Internal helpers
+
+    private func gatherAnswers(
+        hosts: [String],
+        question: LookupQuestion
+    ) async throws -> [LookupAnswer] {
+        await withTaskGroup(of: LookupAnswer?.self) { group in
+            for host in hosts {
+                group.addTask { [facilitator, config, reputation] in
+                    let started = Date()
+                    do {
+                        let answer = try await facilitator.lookup(
+                            host: host,
+                            question: question,
+                            timeout: config.timeout
+                        )
+                        let elapsed = Date().timeIntervalSince(started) * 1000
+                        await reputation.recordSuccess(host: host, latencyMs: elapsed)
+                        return answer
+                    } catch {
+                        await reputation.recordFailure(host: host, immediate: true)
+                        return nil
+                    }
+                }
+            }
+
+            var results: [LookupAnswer] = []
+            var firstArrivedAt: Date?
+            for await maybeAnswer in group {
+                if let answer = maybeAnswer {
+                    results.append(answer)
+                    if firstArrivedAt == nil {
+                        firstArrivedAt = Date()
+                    }
+                }
+                if let first = firstArrivedAt, Date().timeIntervalSince(first) >= config.graceWindow {
+                    group.cancelAll()
+                    break
+                }
+            }
+            return results
+        }
+    }
+
+    /// Merge answers, deduplicating by `(txid,outputIndex)`. The txid is
+    /// derived by parsing the BEEF to get the top-level transaction id.
+    private func mergeAnswers(_ answers: [LookupAnswer]) -> LookupAnswer {
+        var seen = Set<String>()
+        var merged: [LookupOutput] = []
+        for answer in answers {
+            for output in answer.outputs {
+                let key = Self.dedupeKey(for: output)
+                if !seen.contains(key) {
+                    seen.insert(key)
+                    merged.append(output)
+                }
+            }
+        }
+        return LookupAnswer(type: "output-list", outputs: merged)
+    }
+
+    /// Generate a deduplication key for a lookup output using the top-level
+    /// transaction id from its BEEF bundle. Falls back to a raw hash of the
+    /// BEEF bytes when parsing fails.
+    static func dedupeKey(for output: LookupOutput) -> String {
+        if let beef = try? Beef.fromBinary(output.beef) {
+            if let lastTx = beef.transactions.last?.transaction {
+                return "\(lastTx.txid()).\(output.outputIndex)"
+            }
+        }
+        return "\(output.beef.hex).\(output.outputIndex)"
+    }
+}

--- a/Sources/BSV/Overlay/LookupResolver.swift
+++ b/Sources/BSV/Overlay/LookupResolver.swift
@@ -111,7 +111,21 @@ public struct LookupResolver: Sendable {
         hosts: [String],
         question: LookupQuestion
     ) async throws -> [LookupAnswer] {
-        await withTaskGroup(of: LookupAnswer?.self) { group in
+        // The grace-window enum sentinel threads two kinds of events
+        // through a single task group: real lookup answers from each
+        // host, and a single timer task that fires `graceWindow`
+        // seconds after the first answer arrives. The loop below picks
+        // the sentinel out and uses it to cancel the group without
+        // waiting for any remaining slow hosts. The old implementation
+        // only checked elapsed time on the next `for await` iteration,
+        // which meant a fast responder followed by slow hosts stalled
+        // the caller up to `config.timeout`.
+        enum Event: Sendable {
+            case answer(LookupAnswer?)
+            case graceExpired
+        }
+
+        return await withTaskGroup(of: Event.self) { group in
             for host in hosts {
                 group.addTask { [facilitator, config, reputation] in
                     let started = Date()
@@ -123,26 +137,34 @@ public struct LookupResolver: Sendable {
                         )
                         let elapsed = Date().timeIntervalSince(started) * 1000
                         await reputation.recordSuccess(host: host, latencyMs: elapsed)
-                        return answer
+                        return .answer(answer)
                     } catch {
                         await reputation.recordFailure(host: host, immediate: true)
-                        return nil
+                        return .answer(nil)
                     }
                 }
             }
 
             var results: [LookupAnswer] = []
-            var firstArrivedAt: Date?
-            for await maybeAnswer in group {
-                if let answer = maybeAnswer {
-                    results.append(answer)
-                    if firstArrivedAt == nil {
-                        firstArrivedAt = Date()
+            var timerStarted = false
+            let graceNanos = UInt64(max(0, config.graceWindow) * 1_000_000_000)
+
+            while let event = await group.next() {
+                switch event {
+                case .answer(let maybe):
+                    if let answer = maybe {
+                        results.append(answer)
+                        if !timerStarted {
+                            timerStarted = true
+                            group.addTask {
+                                try? await Task.sleep(nanoseconds: graceNanos)
+                                return .graceExpired
+                            }
+                        }
                     }
-                }
-                if let first = firstArrivedAt, Date().timeIntervalSince(first) >= config.graceWindow {
+                case .graceExpired:
                     group.cancelAll()
-                    break
+                    return results
                 }
             }
             return results

--- a/Sources/BSV/Overlay/OverlayAdminTokenTemplate.swift
+++ b/Sources/BSV/Overlay/OverlayAdminTokenTemplate.swift
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// SHIP/SLAP advertisement template (PushDrop-shaped tokens).
+//
+// Ported from ts-sdk src/overlay-tools/OverlayAdminTokenTemplate.ts. The
+// ts-sdk builds these tokens on top of its generic `PushDrop` template;
+// because the Swift SDK does not yet expose a generic PushDrop template,
+// this file inlines the minimal PushDrop layout that SHIP/SLAP needs:
+//
+//     <lockingPubKey> OP_CHECKSIG <protocol> <identityKey> <domain>
+//     <topicOrService> <signature> OP_2DROP OP_2DROP OP_DROP
+//
+// The five fields after OP_CHECKSIG are dropped by the `OP_2DROP OP_2DROP
+// OP_DROP` tail so that the output is spendable as a bare P2PK from the
+// locking key.
+
+import Foundation
+
+/// Result of decoding a SHIP or SLAP advertisement script.
+public struct OverlayAdminAdvertisement: Sendable, Equatable {
+    /// Either `.ship` or `.slap`.
+    public var protocolKind: OverlayAdminProtocol
+    /// Identity key of the advertising host (compressed hex).
+    public var identityKey: String
+    /// Domain under which the host exposes its overlay services.
+    public var domain: String
+    /// For `.ship`: the topic manager name. For `.slap`: the lookup service name.
+    public var topicOrService: String
+
+    public init(
+        protocolKind: OverlayAdminProtocol,
+        identityKey: String,
+        domain: String,
+        topicOrService: String
+    ) {
+        self.protocolKind = protocolKind
+        self.identityKey = identityKey
+        self.domain = domain
+        self.topicOrService = topicOrService
+    }
+}
+
+/// The two advertisement protocols supported by the overlay admin template.
+public enum OverlayAdminProtocol: String, Sendable, Equatable {
+    case ship = "SHIP"
+    case slap = "SLAP"
+
+    /// The BRC-43 protocol name used when signing the locking script fields.
+    public var signingProtocolName: String {
+        switch self {
+        case .ship: return "Service Host Interconnect"
+        case .slap: return "Service Lookup Availability"
+        }
+    }
+}
+
+/// Script template that creates and decodes SHIP/SLAP advertisement tokens.
+public struct OverlayAdminTokenTemplate: Sendable {
+    /// The wallet used to fetch the host identity key and produce signatures.
+    public let wallet: WalletInterface
+    /// Optional BRC-100 originator string.
+    public let originator: String?
+
+    public init(wallet: WalletInterface, originator: String? = nil) {
+        self.wallet = wallet
+        self.originator = originator
+    }
+
+    // MARK: - Decoding
+
+    /// Decode a SHIP or SLAP advertisement from a locking script.
+    public static func decode(_ script: Script) throws -> OverlayAdminAdvertisement {
+        let chunks = script.chunks
+        // Minimum: pubkey push + OP_CHECKSIG + 4 field pushes + OP_2DROP OP_2DROP OP_DROP
+        guard chunks.count >= 10 else {
+            throw OverlayError.invalidAdvertisement("script too short")
+        }
+        // The first chunk is the locking public key push.
+        guard chunks[0].isDataPush, chunks[0].data != nil else {
+            throw OverlayError.invalidAdvertisement("missing locking public key push")
+        }
+        guard chunks[1].opcode == OpCodes.OP_CHECKSIG else {
+            throw OverlayError.invalidAdvertisement("expected OP_CHECKSIG after locking public key")
+        }
+
+        // Locate the tail of OP_2DROP/OP_DROP ops to bound the field region.
+        var fieldEnd = chunks.count
+        while fieldEnd > 2 {
+            let op = chunks[fieldEnd - 1].opcode
+            if op == OpCodes.OP_2DROP || op == OpCodes.OP_DROP {
+                fieldEnd -= 1
+                continue
+            }
+            break
+        }
+        // Fields region is [2, fieldEnd) — must contain at least 4 pushes.
+        guard fieldEnd - 2 >= 4 else {
+            throw OverlayError.invalidAdvertisement("fewer than 4 data fields")
+        }
+
+        func pushData(at index: Int) throws -> Data {
+            let chunk = chunks[index]
+            if let data = chunk.data { return data }
+            // Small-int opcodes (OP_0..OP_16, OP_1NEGATE) push conceptually non-empty data.
+            if chunk.opcode == OpCodes.OP_0 { return Data([0]) }
+            if chunk.opcode >= 0x51 && chunk.opcode <= 0x60 {
+                return Data([chunk.opcode - 0x50])
+            }
+            if chunk.opcode == 0x4f { return Data([0x81]) }
+            throw OverlayError.invalidAdvertisement("non-push opcode within fields region")
+        }
+
+        let protocolBytes = try pushData(at: 2)
+        let identityKeyBytes = try pushData(at: 3)
+        let domainBytes = try pushData(at: 4)
+        let topicBytes = try pushData(at: 5)
+
+        guard let protocolString = String(data: protocolBytes, encoding: .utf8),
+              let kind = OverlayAdminProtocol(rawValue: protocolString) else {
+            throw OverlayError.invalidAdvertisement("protocol field is not SHIP or SLAP")
+        }
+        guard let domain = String(data: domainBytes, encoding: .utf8) else {
+            throw OverlayError.invalidAdvertisement("domain is not valid UTF-8")
+        }
+        guard let topicOrService = String(data: topicBytes, encoding: .utf8) else {
+            throw OverlayError.invalidAdvertisement("topicOrService is not valid UTF-8")
+        }
+
+        return OverlayAdminAdvertisement(
+            protocolKind: kind,
+            identityKey: identityKeyBytes.hex,
+            domain: domain,
+            topicOrService: topicOrService
+        )
+    }
+
+    // MARK: - Locking
+
+    /// Build a SHIP or SLAP advertisement locking script.
+    ///
+    /// The script has the shape:
+    ///
+    ///     <pubkey> OP_CHECKSIG <protocol> <identityKey> <domain>
+    ///     <topicOrService> <signature> OP_2DROP OP_2DROP OP_DROP
+    public func lock(
+        protocol kind: OverlayAdminProtocol,
+        domain: String,
+        topicOrService: String
+    ) async throws -> Script {
+        let protocolID = WalletProtocol(
+            securityLevel: .counterparty,
+            protocol: kind.signingProtocolName
+        )
+        let encryption = WalletEncryptionArgs(
+            protocolID: protocolID,
+            keyID: "1",
+            counterparty: .`self`
+        )
+
+        // Identity key of the advertising host.
+        let identityResult = try await wallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        )
+        let identityKey = identityResult.publicKey
+
+        // Locking public key derived via BRC-42 for this protocol/key/self.
+        let lockingKeyResult = try await wallet.getPublicKey(
+            args: GetPublicKeyArgs(encryption: encryption)
+        )
+        let lockingKey = lockingKeyResult.publicKey
+
+        var fields: [Data] = [
+            Data(kind.rawValue.utf8),
+            identityKey.toCompressed(),
+            Data(domain.utf8),
+            Data(topicOrService.utf8)
+        ]
+
+        // The data signed by PushDrop tokens is the concatenation of the fields.
+        var dataToSign = Data()
+        for field in fields { dataToSign.append(field) }
+
+        let signatureResult = try await wallet.createSignature(args: CreateSignatureArgs(
+            encryption: encryption,
+            data: dataToSign
+        ))
+        fields.append(signatureResult.signature)
+
+        var bytes = Data()
+
+        // <pubkey> OP_CHECKSIG ...
+        let lockingKeyBytes = lockingKey.toCompressed()
+        bytes.append(ScriptChunk.encodePushData(lockingKeyBytes).toBinary())
+        bytes.append(OpCodes.OP_CHECKSIG)
+
+        // Field pushes.
+        for field in fields {
+            bytes.append(Self.minimalPushChunk(for: field).toBinary())
+        }
+
+        // Drop every field with OP_2DROP until at most one remains, then OP_DROP.
+        var notYetDropped = fields.count
+        while notYetDropped > 1 {
+            bytes.append(OpCodes.OP_2DROP)
+            notYetDropped -= 2
+        }
+        if notYetDropped != 0 {
+            bytes.append(OpCodes.OP_DROP)
+        }
+
+        return Script(data: bytes)
+    }
+
+    // MARK: - Helpers
+
+    /// Minimal encoding for a PushDrop-style field push. Matches the
+    /// `createMinimallyEncodedScriptChunk` helper in ts-sdk.
+    static func minimalPushChunk(for data: Data) -> ScriptChunk {
+        if data.isEmpty {
+            return ScriptChunk(opcode: OpCodes.OP_0)
+        }
+        if data.count == 1 {
+            let byte = data[data.startIndex]
+            if byte == 0 {
+                return ScriptChunk(opcode: OpCodes.OP_0)
+            }
+            if byte > 0 && byte <= 16 {
+                return ScriptChunk(opcode: 0x50 + byte)
+            }
+            if byte == 0x81 {
+                // OP_1NEGATE
+                return ScriptChunk(opcode: 0x4f)
+            }
+        }
+        return ScriptChunk.encodePushData(data)
+    }
+}

--- a/Sources/BSV/Overlay/OverlayError.swift
+++ b/Sources/BSV/Overlay/OverlayError.swift
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Error cases raised by the overlay tools (SHIP broadcasters, lookup
+// resolvers, and the overlay admin token template).
+
+import Foundation
+
+/// Errors raised by the overlay tools module.
+public enum OverlayError: Error, LocalizedError, Equatable {
+    /// A topic name did not start with the required `tm_` prefix.
+    case invalidTopicPrefix(String)
+    /// A lookup service name did not start with the required `ls_` prefix.
+    case invalidServiceName(String)
+    /// No SHIP/SLAP hosts were interested in the supplied topics or service.
+    case noHostsInterested(String)
+    /// The acknowledgment policy was violated by the gathered responses.
+    case acknowledgmentFailure(String)
+    /// The overlay advertisement token was structurally invalid.
+    case invalidAdvertisement(String)
+    /// A lookup response was malformed or unreadable.
+    case invalidLookupResponse(String)
+    /// The supplied URL could not be parsed.
+    case invalidURL(String)
+    /// A transport/network failure occurred.
+    case networkFailure(String)
+    /// An operation needed a property that was missing or malformed.
+    case missingField(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidTopicPrefix(let topic):
+            return "Invalid topic prefix (expected 'tm_'): \(topic)"
+        case .invalidServiceName(let name):
+            return "Invalid lookup service name (expected 'ls_' prefix): \(name)"
+        case .noHostsInterested(let detail):
+            return "No overlay hosts were interested: \(detail)"
+        case .acknowledgmentFailure(let detail):
+            return "Overlay acknowledgment failure: \(detail)"
+        case .invalidAdvertisement(let detail):
+            return "Invalid SHIP/SLAP advertisement: \(detail)"
+        case .invalidLookupResponse(let detail):
+            return "Invalid lookup response: \(detail)"
+        case .invalidURL(let url):
+            return "Invalid URL: \(url)"
+        case .networkFailure(let detail):
+            return "Overlay network failure: \(detail)"
+        case .missingField(let field):
+            return "Missing field: \(field)"
+        }
+    }
+}

--- a/Sources/BSV/Overlay/OverlayFacilitators.swift
+++ b/Sources/BSV/Overlay/OverlayFacilitators.swift
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Overlay broadcast and lookup facilitators.
+//
+// Ported from ts-sdk src/overlay-tools/SHIPBroadcaster.ts and
+// src/overlay-tools/LookupResolver.ts. Facilitators abstract the transport
+// that talks to a single overlay host so the broadcast/lookup logic can be
+// unit-tested without network access.
+
+import Foundation
+
+/// A broadcast facilitator pushes a tagged BEEF payload to a single overlay
+/// host and returns the per-topic admittance instructions.
+public protocol OverlayBroadcastFacilitator: Sendable {
+    /// Submit `taggedBEEF` to `host` and return the STEAK response.
+    ///
+    /// - Parameters:
+    ///   - host: The base URL of the overlay host (without `/submit` suffix).
+    ///   - taggedBEEF: The BEEF payload, the targeted topics, and any
+    ///     off-chain values required by the overlay service.
+    ///   - timeout: Optional request timeout in seconds.
+    func send(
+        host: String,
+        taggedBEEF: TaggedBEEF,
+        timeout: TimeInterval?
+    ) async throws -> STEAK
+}
+
+/// A lookup facilitator forwards a `LookupQuestion` to a single overlay host
+/// and returns the decoded `LookupAnswer`.
+public protocol OverlayLookupFacilitator: Sendable {
+    /// Query `host` with `question`.
+    ///
+    /// - Parameters:
+    ///   - host: The base URL of the overlay host (without `/lookup` suffix).
+    ///   - question: The structured lookup question.
+    ///   - timeout: Optional request timeout in seconds.
+    func lookup(
+        host: String,
+        question: LookupQuestion,
+        timeout: TimeInterval?
+    ) async throws -> LookupAnswer
+}
+
+// MARK: - HTTPS broadcast facilitator
+
+/// HTTPS implementation of `OverlayBroadcastFacilitator`. Posts the BEEF to
+/// `<host>/submit` with the `X-Topics` header, matching ts-sdk's
+/// `HTTPSOverlayBroadcastFacilitator`.
+public struct HTTPSOverlayBroadcastFacilitator: OverlayBroadcastFacilitator {
+    public let urlSession: URLSession
+
+    public init(urlSession: URLSession = .shared) {
+        self.urlSession = urlSession
+    }
+
+    public func send(
+        host: String,
+        taggedBEEF: TaggedBEEF,
+        timeout: TimeInterval?
+    ) async throws -> STEAK {
+        guard let url = URL(string: host.trimmingTrailingSlash() + "/submit") else {
+            throw OverlayError.invalidURL(host)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let timeout { request.timeoutInterval = timeout }
+
+        // The X-Topics header is a JSON-encoded array of topic names.
+        let topicsJSON = try JSONSerialization.data(withJSONObject: taggedBEEF.topics)
+        if let topicsString = String(data: topicsJSON, encoding: .utf8) {
+            request.setValue(topicsString, forHTTPHeaderField: "X-Topics")
+        }
+        request.httpBody = taggedBEEF.beef
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            throw OverlayError.networkFailure(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw OverlayError.networkFailure("response is not HTTP")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw OverlayError.networkFailure("HTTP \(http.statusCode): \(body)")
+        }
+
+        return try Self.decodeSTEAK(data: data)
+    }
+
+    /// Decode a STEAK JSON body of the form:
+    /// `{ "<topic>": { "outputsToAdmit": [...], "coinsToRetain": [...], "coinsRemoved": [...] } }`.
+    static func decodeSTEAK(data: Data) throws -> STEAK {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OverlayError.networkFailure("STEAK response is not a JSON object")
+        }
+        var steak: STEAK = [:]
+        for (topic, raw) in json {
+            guard let entry = raw as? [String: Any] else {
+                throw OverlayError.networkFailure("STEAK entry for \(topic) is not an object")
+            }
+            let outputs = (entry["outputsToAdmit"] as? [Any])?.compactMap { value -> UInt32? in
+                if let n = value as? Int { return UInt32(exactly: n) }
+                if let n = value as? Double { return UInt32(exactly: n) }
+                return nil
+            } ?? []
+            let retain = (entry["coinsToRetain"] as? [String]) ?? []
+            let removed = entry["coinsRemoved"] as? [String]
+            steak[topic] = AdmittanceInstructions(
+                outputsToAdmit: outputs,
+                coinsToRetain: retain,
+                coinsRemoved: removed
+            )
+        }
+        return steak
+    }
+}
+
+// MARK: - HTTPS lookup facilitator
+
+/// HTTPS implementation of `OverlayLookupFacilitator`. Posts the question
+/// to `<host>/lookup` and parses the JSON response.
+public struct HTTPSOverlayLookupFacilitator: OverlayLookupFacilitator {
+    public let urlSession: URLSession
+
+    public init(urlSession: URLSession = .shared) {
+        self.urlSession = urlSession
+    }
+
+    public func lookup(
+        host: String,
+        question: LookupQuestion,
+        timeout: TimeInterval?
+    ) async throws -> LookupAnswer {
+        guard let url = URL(string: host.trimmingTrailingSlash() + "/lookup") else {
+            throw OverlayError.invalidURL(host)
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("yes", forHTTPHeaderField: "X-Aggregation")
+        if let timeout { request.timeoutInterval = timeout }
+
+        // Body shape matches ts-sdk: { service, query }
+        let queryAny: Any
+        if let queryObject = try? JSONSerialization.jsonObject(with: question.query) {
+            queryAny = queryObject
+        } else if let queryString = String(data: question.query, encoding: .utf8) {
+            queryAny = queryString
+        } else {
+            queryAny = question.query.hex
+        }
+        let body: [String: Any] = [
+            "service": question.service,
+            "query": queryAny
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await urlSession.data(for: request)
+        } catch {
+            throw OverlayError.networkFailure(error.localizedDescription)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw OverlayError.networkFailure("response is not HTTP")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let bodyString = String(data: data, encoding: .utf8) ?? ""
+            throw OverlayError.networkFailure("HTTP \(http.statusCode): \(bodyString)")
+        }
+        return try Self.decodeAnswer(data: data)
+    }
+
+    /// Parse a lookup answer from either JSON or the binary aggregated
+    /// format described in ts-sdk's `HTTPSOverlayLookupFacilitator`.
+    static func decodeAnswer(data: Data) throws -> LookupAnswer {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let type = (json["type"] as? String) ?? "output-list"
+            let rawOutputs = (json["outputs"] as? [[String: Any]]) ?? []
+            var outputs: [LookupOutput] = []
+            for raw in rawOutputs {
+                guard let beefHex = raw["beef"] as? String,
+                      let beef = Data(hex: beefHex) else {
+                    throw OverlayError.invalidLookupResponse("missing or invalid beef field")
+                }
+                let index: UInt32
+                if let n = raw["outputIndex"] as? Int {
+                    index = UInt32(n)
+                } else if let n = raw["outputIndex"] as? Double {
+                    index = UInt32(n)
+                } else {
+                    throw OverlayError.invalidLookupResponse("missing outputIndex")
+                }
+                var context: Data?
+                if let ctxString = raw["context"] as? String {
+                    context = Data(hex: ctxString) ?? Data(ctxString.utf8)
+                }
+                outputs.append(LookupOutput(beef: beef, outputIndex: index, context: context))
+            }
+            return LookupAnswer(type: type, outputs: outputs)
+        }
+        throw OverlayError.invalidLookupResponse("response is not valid JSON")
+    }
+}
+
+// MARK: - Helpers
+
+extension String {
+    fileprivate func trimmingTrailingSlash() -> String {
+        var result = self
+        while result.hasSuffix("/") { result.removeLast() }
+        return result
+    }
+}

--- a/Sources/BSV/Overlay/OverlayTypes.swift
+++ b/Sources/BSV/Overlay/OverlayTypes.swift
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Shared data types used by SHIP broadcasters and overlay lookup resolvers.
+//
+// Ported from ts-sdk src/overlay-tools/SHIPBroadcaster.ts and
+// src/overlay-tools/LookupResolver.ts.
+
+import Foundation
+
+/// A BEEF bundle tagged with the overlay topics it targets.
+///
+/// Off-chain values may optionally be attached and are forwarded alongside
+/// the BEEF payload when overlay services require additional context that
+/// does not live on-chain.
+public struct TaggedBEEF: Sendable, Equatable {
+    /// The raw BEEF bytes (BRC-62 / BRC-96).
+    public var beef: Data
+    /// Overlay topic names (each of the form `tm_<topic>`).
+    public var topics: [String]
+    /// Optional off-chain values keyed by an arbitrary string label.
+    public var offChainValues: [String: Data]?
+
+    public init(
+        beef: Data,
+        topics: [String],
+        offChainValues: [String: Data]? = nil
+    ) {
+        self.beef = beef
+        self.topics = topics
+        self.offChainValues = offChainValues
+    }
+}
+
+/// Instructions returned by an overlay host describing how it has admitted
+/// the submitted transaction into a given topic.
+public struct AdmittanceInstructions: Sendable, Equatable {
+    /// Output indices admitted by the host for the topic.
+    public var outputsToAdmit: [UInt32]
+    /// Coin outpoints that the host intends to retain.
+    public var coinsToRetain: [String]
+    /// Coin outpoints removed by the host as part of admittance.
+    public var coinsRemoved: [String]?
+
+    public init(
+        outputsToAdmit: [UInt32] = [],
+        coinsToRetain: [String] = [],
+        coinsRemoved: [String]? = nil
+    ) {
+        self.outputsToAdmit = outputsToAdmit
+        self.coinsToRetain = coinsToRetain
+        self.coinsRemoved = coinsRemoved
+    }
+}
+
+/// Submitted Transaction Execution AcKnowledgment.
+///
+/// A dictionary keyed by topic where the value is the per-topic
+/// admittance instructions returned by a single overlay host.
+public typealias STEAK = [String: AdmittanceInstructions]
+
+/// Acknowledgment policy for a SHIP broadcast.
+public enum SHIPAcknowledgmentRequirement: Sendable, Equatable {
+    /// Every host interested in every topic must acknowledge.
+    case allHostsForAllTopics
+    /// At least one host must acknowledge each topic.
+    case anyHostForEachTopic
+    /// Per-topic host-URL lists must acknowledge.
+    case specificHosts([String: [String]])
+}
+
+/// Configuration for a SHIP broadcaster.
+public struct SHIPBroadcasterConfig: Sendable {
+    /// Which overlay network to resolve hosts from.
+    public var networkPreset: OverlayNetworkPreset
+    /// Acknowledgment policy the broadcast must satisfy.
+    public var requirement: SHIPAcknowledgmentRequirement
+    /// Optional URL overrides for resolving SLAP trackers.
+    public var slapTrackers: [String]?
+
+    public init(
+        networkPreset: OverlayNetworkPreset = .mainnet,
+        requirement: SHIPAcknowledgmentRequirement = .anyHostForEachTopic,
+        slapTrackers: [String]? = nil
+    ) {
+        self.networkPreset = networkPreset
+        self.requirement = requirement
+        self.slapTrackers = slapTrackers
+    }
+}
+
+/// Overlay network selector mirroring the ts-sdk `NetworkPreset` enum.
+public enum OverlayNetworkPreset: String, Sendable, Equatable {
+    case mainnet
+    case testnet
+    case local
+}
+
+/// A structured lookup question submitted to an overlay lookup service.
+public struct LookupQuestion: Sendable, Equatable {
+    /// The service name (must start with `ls_`).
+    public var service: String
+    /// The opaque query payload (JSON-encoded by the caller).
+    public var query: Data
+
+    public init(service: String, query: Data) {
+        self.service = service
+        self.query = query
+    }
+}
+
+/// A single output returned in a lookup answer.
+public struct LookupOutput: Sendable, Equatable {
+    /// The BEEF bundle that proves the output's provenance.
+    public var beef: Data
+    /// The index of the output within the top-level transaction of `beef`.
+    public var outputIndex: UInt32
+    /// Optional opaque context supplied by the lookup service.
+    public var context: Data?
+
+    public init(beef: Data, outputIndex: UInt32, context: Data? = nil) {
+        self.beef = beef
+        self.outputIndex = outputIndex
+        self.context = context
+    }
+}
+
+/// The structured response from a lookup query.
+public struct LookupAnswer: Sendable, Equatable {
+    /// The response type (mirrors ts-sdk's string discriminator).
+    public var type: String
+    /// The list of outputs returned by the service.
+    public var outputs: [LookupOutput]
+
+    public init(type: String = "output-list", outputs: [LookupOutput]) {
+        self.type = type
+        self.outputs = outputs
+    }
+}

--- a/Sources/BSV/Overlay/SHIPBroadcaster.swift
+++ b/Sources/BSV/Overlay/SHIPBroadcaster.swift
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Service Host Interconnect Protocol broadcaster.
+//
+// Ported from ts-sdk src/overlay-tools/SHIPBroadcaster.ts. A SHIPBroadcaster
+// takes a transaction targeted at one or more `tm_*` topics, queries the
+// overlay network for hosts that are interested in each topic, and posts
+// the BEEF to the intersection of those hosts. It satisfies the Phase 5
+// `Broadcaster` protocol so callers can plug it in anywhere a `Broadcaster`
+// is expected.
+//
+// The broadcaster does not itself discover hosts — a `SHIPHostResolver`
+// implementation must be provided. In tests this is typically a stub that
+// returns a fixed map of topic → hosts. A production `LookupResolver`-based
+// implementation can be layered on top.
+
+import Foundation
+
+/// Resolves overlay hosts that are interested in a given set of topics.
+public protocol SHIPHostResolver: Sendable {
+    /// Return hosts (base URLs, e.g. `https://overlay.example.com`) that
+    /// currently claim to host each of the requested topics.
+    func hosts(forTopics topics: [String]) async throws -> [String: [String]]
+}
+
+/// A SHIP broadcaster that delegates host discovery to a `SHIPHostResolver`
+/// and per-host submission to an `OverlayBroadcastFacilitator`.
+public struct SHIPBroadcaster: Broadcaster, Sendable {
+    /// The topics that every transaction broadcast by this instance targets.
+    public let topics: [String]
+    /// Resolver used to find hosts interested in the configured topics.
+    public let hostResolver: SHIPHostResolver
+    /// Per-host submission transport.
+    public let facilitator: OverlayBroadcastFacilitator
+    /// Reputation tracker used to prefer fast/healthy hosts.
+    public let reputation: HostReputationTracker
+    /// Acknowledgment policy that determines when a broadcast is successful.
+    public let config: SHIPBroadcasterConfig
+    /// Optional off-chain values to forward with every submission.
+    public let offChainValues: [String: Data]?
+    /// Per-request timeout (seconds) forwarded to the facilitator.
+    public let timeout: TimeInterval?
+
+    /// Construct a SHIPBroadcaster.
+    ///
+    /// - Parameters:
+    ///   - topics: The overlay topics (`tm_*`) targeted by every broadcast.
+    ///   - hostResolver: Component that maps topics to interested hosts.
+    ///   - facilitator: Per-host transport. Defaults to HTTPS.
+    ///   - reputation: Reputation tracker (defaults to a fresh actor).
+    ///   - config: Acknowledgment policy and network preset.
+    ///   - offChainValues: Optional off-chain values to forward.
+    ///   - timeout: Optional per-host request timeout in seconds.
+    /// - Throws: `OverlayError.invalidTopicPrefix` if any topic lacks the
+    ///   `tm_` prefix.
+    public init(
+        topics: [String],
+        hostResolver: SHIPHostResolver,
+        facilitator: OverlayBroadcastFacilitator = HTTPSOverlayBroadcastFacilitator(),
+        reputation: HostReputationTracker = HostReputationTracker(),
+        config: SHIPBroadcasterConfig = SHIPBroadcasterConfig(),
+        offChainValues: [String: Data]? = nil,
+        timeout: TimeInterval? = 30
+    ) throws {
+        for topic in topics where !topic.hasPrefix("tm_") {
+            throw OverlayError.invalidTopicPrefix(topic)
+        }
+        self.topics = topics
+        self.hostResolver = hostResolver
+        self.facilitator = facilitator
+        self.reputation = reputation
+        self.config = config
+        self.offChainValues = offChainValues
+        self.timeout = timeout
+    }
+
+    // MARK: - Broadcaster
+
+    public func broadcast(_ transaction: Transaction) async throws -> BroadcastResponse {
+        // Wrap the transaction in a single-tx BEEF.
+        let beef = Beef(
+            version: beefV2Version,
+            bumps: [],
+            transactions: [BeefTx(dataFormat: .rawTx, transaction: transaction)]
+        )
+        let tagged = TaggedBEEF(
+            beef: beef.toBinary(),
+            topics: topics,
+            offChainValues: offChainValues
+        )
+        let acks = try await broadcastTagged(tagged)
+        let txid = transaction.txid()
+        return BroadcastResponse(
+            txid: txid,
+            status: "OVERLAY_BROADCAST_OK",
+            description: "\(acks.count) overlay host acknowledgments"
+        )
+    }
+
+    /// Broadcast an already-built tagged BEEF. Returns the per-host
+    /// acknowledgments that satisfied the broadcaster's policy.
+    public func broadcastTagged(_ taggedBEEF: TaggedBEEF) async throws -> [String: STEAK] {
+        guard !taggedBEEF.topics.isEmpty else {
+            throw OverlayError.noHostsInterested("no topics supplied")
+        }
+
+        // Discover interested hosts and remove any that are currently in
+        // back-off. Each host is queried at most once even if it covers
+        // multiple topics.
+        let interested = try await hostResolver.hosts(forTopics: taggedBEEF.topics)
+        var hosts = Set<String>()
+        for (_, list) in interested {
+            for host in list { hosts.insert(host) }
+        }
+        var filtered: [String] = []
+        for host in hosts where !(await reputation.isInBackoff(host: host)) {
+            filtered.append(host)
+        }
+        if filtered.isEmpty {
+            throw OverlayError.noHostsInterested(
+                "no overlay hosts available for topics \(taggedBEEF.topics.joined(separator: ","))"
+            )
+        }
+        let ranked = await reputation.rank(hosts: filtered)
+
+        // Submit to every host in parallel and collect STEAK results.
+        var responses: [String: STEAK] = [:]
+        var failures: [String: Error] = [:]
+        await withTaskGroup(of: (String, Result<STEAK, Error>).self) { group in
+            for host in ranked {
+                group.addTask { [facilitator, timeout, reputation] in
+                    let started = Date()
+                    do {
+                        let steak = try await facilitator.send(
+                            host: host,
+                            taggedBEEF: taggedBEEF,
+                            timeout: timeout
+                        )
+                        let elapsed = Date().timeIntervalSince(started) * 1000
+                        await reputation.recordSuccess(host: host, latencyMs: elapsed)
+                        return (host, .success(steak))
+                    } catch {
+                        await reputation.recordFailure(host: host, immediate: true)
+                        return (host, .failure(error))
+                    }
+                }
+            }
+            for await (host, result) in group {
+                switch result {
+                case .success(let steak): responses[host] = steak
+                case .failure(let err): failures[host] = err
+                }
+            }
+        }
+
+        // Evaluate the acknowledgment policy.
+        try evaluateAcknowledgments(
+            responses: responses,
+            requested: taggedBEEF.topics,
+            interestMap: interested,
+            failures: failures
+        )
+        return responses
+    }
+
+    /// Enforce the configured acknowledgment requirement against the
+    /// set of successful STEAK responses.
+    private func evaluateAcknowledgments(
+        responses: [String: STEAK],
+        requested: [String],
+        interestMap: [String: [String]],
+        failures: [String: Error]
+    ) throws {
+        switch config.requirement {
+        case .allHostsForAllTopics:
+            for topic in requested {
+                let expected = interestMap[topic] ?? []
+                for host in expected {
+                    guard let steak = responses[host], steak[topic] != nil else {
+                        throw OverlayError.acknowledgmentFailure(
+                            "host \(host) did not acknowledge topic \(topic)"
+                        )
+                    }
+                }
+            }
+        case .anyHostForEachTopic:
+            for topic in requested {
+                let acknowledged = responses.contains { _, steak in steak[topic] != nil }
+                if !acknowledged {
+                    throw OverlayError.acknowledgmentFailure(
+                        "no host acknowledged topic \(topic)"
+                    )
+                }
+            }
+        case .specificHosts(let required):
+            for (topic, hosts) in required {
+                for host in hosts {
+                    guard let steak = responses[host], steak[topic] != nil else {
+                        throw OverlayError.acknowledgmentFailure(
+                            "host \(host) did not acknowledge topic \(topic)"
+                        )
+                    }
+                }
+            }
+        }
+        _ = failures
+    }
+}

--- a/Sources/BSV/Overlay/WithDoubleSpendRetry.swift
+++ b/Sources/BSV/Overlay/WithDoubleSpendRetry.swift
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Retry helper that reacts to double-spend errors by re-broadcasting the
+// competing transaction before retrying the original operation.
+//
+// Ported from ts-sdk src/overlay-tools/withDoubleSpendRetry.ts. Swift does
+// not have a direct equivalent of the ts-sdk `WERR_REVIEW_ACTIONS` class,
+// so we express double-spend detection via a small protocol that callers
+// can conform their own error types to. The retry helper itself is a
+// generic async function that runs `operation` up to `maxRetries` times,
+// broadcasting the competing transaction on the overlay whenever the
+// operation throws a double-spend error.
+
+import Foundation
+
+/// The maximum number of retries attempted by `withDoubleSpendRetry`.
+public let defaultDoubleSpendRetryLimit = 5
+
+/// A competing transaction reported by a wallet review-action error.
+public struct DoubleSpendCompetingAction: Sendable {
+    /// The serialised BEEF of the competing transaction chain.
+    public var beef: Data
+    /// The txid of the competing transaction (display order hex).
+    public var txid: String
+
+    public init(beef: Data, txid: String) {
+        self.beef = beef
+        self.txid = txid
+    }
+}
+
+/// An error that exposes a double-spend competing action. Conform the
+/// wallet's action-review error type to this protocol to opt into the
+/// retry loop.
+public protocol DoubleSpendReportingError: Error {
+    /// Return the competing action details, or `nil` if the error is not
+    /// a double-spend.
+    var competingAction: DoubleSpendCompetingAction? { get }
+}
+
+/// Attempt `operation` up to `maxRetries` times, broadcasting the
+/// competing transaction on the overlay between retries when a
+/// double-spend error is reported.
+///
+/// - Parameters:
+///   - maxRetries: Maximum number of attempts.
+///   - broadcaster: The SHIP broadcaster used to sync missing state.
+///   - operation: The async operation to run.
+/// - Throws: The underlying error if all retries are exhausted or the
+///   error is not a double-spend.
+public func withDoubleSpendRetry<T: Sendable>(
+    maxRetries: Int = defaultDoubleSpendRetryLimit,
+    broadcaster: SHIPBroadcaster,
+    operation: @Sendable () async throws -> T
+) async throws -> T {
+    var attempts = 0
+    var lastError: Error = OverlayError.networkFailure("retry loop did not execute")
+
+    while attempts < maxRetries {
+        attempts += 1
+        do {
+            return try await operation()
+        } catch let error as DoubleSpendReportingError {
+            lastError = error
+            guard attempts < maxRetries,
+                  let competing = error.competingAction else {
+                throw error
+            }
+            do {
+                let beef = try Beef.fromBinary(competing.beef)
+                let tx: Transaction? = beef.transactions
+                    .last(where: { $0.transaction != nil })?
+                    .transaction
+                if let competingTx = tx {
+                    // Broadcast the competing transaction so the overlay
+                    // picks up the state we were missing, then retry.
+                    _ = try await broadcaster.broadcast(competingTx)
+                }
+            } catch {
+                // If the competing broadcast fails, rethrow the original
+                // double-spend error so the caller sees the real cause.
+                throw lastError
+            }
+        } catch {
+            throw error
+        }
+    }
+
+    throw lastError
+}

--- a/Sources/BSV/Primitives/ByteReader.swift
+++ b/Sources/BSV/Primitives/ByteReader.swift
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Minimal cursor-based byte reader shared across the SDK.
+//
+// The wider transaction parser uses a plain `inout Int` offset because
+// it works with strongly typed fields and wants to push decoding errors
+// back to the caller. `ByteReader` is a lighter alternative for call
+// sites that just want to walk a buffer and get `nil` back when they
+// run out of bytes — used today by the certificate parser and
+// available for any other pure-byte parsing tasks.
+
+import Foundation
+
+/// Cursor-based reader over a `Data` buffer. Returns `nil` when a read
+/// would run past the end of the buffer so callers can short-circuit
+/// cleanly without try/catch boilerplate.
+struct ByteReader {
+    private let buffer: Data
+    private var cursor: Int
+
+    init(_ buffer: Data) {
+        self.buffer = buffer
+        self.cursor = 0
+    }
+
+    /// Read exactly `count` bytes, advancing the cursor. Returns `nil`
+    /// if fewer than `count` bytes remain.
+    mutating func read(_ count: Int) -> Data? {
+        guard count >= 0, cursor + count <= buffer.count else { return nil }
+        let slice = buffer.subdata(in: (buffer.startIndex + cursor)..<(buffer.startIndex + cursor + count))
+        cursor += count
+        return slice
+    }
+
+    /// Decode a Bitcoin VarInt at the cursor position, advancing the
+    /// cursor past the encoded bytes. Returns `nil` on a truncated or
+    /// malformed VarInt.
+    mutating func readVarInt() -> UInt64? {
+        guard let decoded = VarInt.decode(buffer, offset: cursor) else { return nil }
+        cursor += decoded.bytesRead
+        return decoded.value
+    }
+
+    /// Return the unread tail of the buffer without advancing the cursor.
+    func remaining() -> Data {
+        guard cursor < buffer.count else { return Data() }
+        return buffer.subdata(in: (buffer.startIndex + cursor)..<buffer.endIndex)
+    }
+}

--- a/Sources/BSV/Primitives/ConstantTime.swift
+++ b/Sources/BSV/Primitives/ConstantTime.swift
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Open BSV License Version 5
+// Constant-time byte comparison helpers shared across the SDK.
+//
+// Used wherever a buffer comparison must not leak information about
+// which byte diverged — for example HMAC / MAC verification in
+// `ProtoWallet` and `AuthNonce`. Lifting this out of `ProtoWallet`
+// avoids cross-module reach-through from the Auth layer.
+
+import Foundation
+
+/// Byte helpers that run in data-independent time.
+enum ConstantTime {
+    /// Compare two byte buffers without early-exit, so the comparison
+    /// takes the same time regardless of where they first differ. Returns
+    /// `false` immediately when the lengths differ — length is not a
+    /// secret in the SDK's use cases.
+    static func equal(_ a: Data, _ b: Data) -> Bool {
+        guard a.count == b.count else { return false }
+        var diff: UInt8 = 0
+        for i in 0..<a.count {
+            diff |= a[a.startIndex + i] ^ b[b.startIndex + i]
+        }
+        return diff == 0
+    }
+}

--- a/Sources/BSV/Primitives/FieldP.swift
+++ b/Sources/BSV/Primitives/FieldP.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Scalar arithmetic modulo the secp256k1 field prime P.
+///
+/// Thin Data-oriented facade around `FieldElement`, which implements fast
+/// secp256k1-specific modular reduction. These helpers are used by Shamir
+/// Secret Sharing, which operates on polynomials over GF(P) to match the
+/// ts-sdk/go-sdk split/recombine format.
+///
+/// All inputs and outputs are 32-byte big-endian `Data` values reduced
+/// modulo P.
+enum FieldP {
+
+    // MARK: - Padding / reduction
+
+    /// Left-pad a byte string to 32 bytes, or return the last 32 bytes if longer.
+    /// Does not reduce modulo P.
+    static func pad(_ data: Data) -> Data {
+        if data.count == 32 { return Data(data) }
+        if data.count < 32 {
+            var padded = Data(count: 32 - data.count)
+            padded.append(data)
+            return padded
+        }
+        return Data(data.suffix(32))
+    }
+
+    /// Reduce a byte string of up to 64 bytes to a 32-byte value mod P.
+    ///
+    /// For 32-byte (or shorter) inputs, this is a single normalise step. For
+    /// 33–64 byte inputs (e.g. HMAC-SHA512 outputs), the value is split into a
+    /// high half and low half and folded via the identity
+    /// `2^256 ≡ 2^32 + 977 (mod P)`.
+    static func reduce(_ data: Data) -> Data {
+        if data.count <= 32 {
+            return normalise32(pad(data))
+        }
+        // Split into high and low 32-byte halves.
+        let high = Data(data.prefix(data.count - 32))
+        let low = Data(data.suffix(32))
+        // Normalise both halves into FieldElements mod P.
+        let highNorm = normalise32(pad(high))
+        let lowNorm = normalise32(pad(low))
+        // Compute (high * 2^256 + low) mod P = (high * c + low) mod P,
+        // where c = 2^32 + 977.
+        let prod = mul(highNorm, c32Data)
+        return add(prod, lowNorm)
+    }
+
+    // MARK: - Core arithmetic
+
+    /// Add two 32-byte scalars modulo P.
+    static func add(_ a: Data, _ b: Data) -> Data {
+        var fa = FieldElement(bytes: normalise32(pad(a)))
+        let fb = FieldElement(bytes: normalise32(pad(b)))
+        fa.add(fb)
+        fa.normalise()
+        return fa.toBytes()
+    }
+
+    /// Subtract `b` from `a` modulo P.
+    static func sub(_ a: Data, _ b: Data) -> Data {
+        var fa = FieldElement(bytes: normalise32(pad(a)))
+        let fb = FieldElement(bytes: normalise32(pad(b)))
+        let negFb = fb.negated(magnitude: 1)
+        fa.add(negFb)
+        fa.normalise()
+        return fa.toBytes()
+    }
+
+    /// Multiply two 32-byte scalars modulo P.
+    static func mul(_ a: Data, _ b: Data) -> Data {
+        let fa = FieldElement(bytes: normalise32(pad(a)))
+        let fb = FieldElement(bytes: normalise32(pad(b)))
+        var r = FieldElement.mul(fa, fb)
+        r.normalise()
+        return r.toBytes()
+    }
+
+    /// Modular inverse a^(-1) mod P using the fast secp256k1-specific
+    /// exponentiation chain in `FieldElement.inversed()`.
+    static func inverse(_ a: Data) -> Data {
+        let fa = FieldElement(bytes: normalise32(pad(a)))
+        var inv = fa.inversed()
+        inv.normalise()
+        return inv.toBytes()
+    }
+
+    // MARK: - Private helpers
+
+    /// Reduce a 32-byte value mod P via `FieldElement.normalise`. Handles
+    /// inputs that slightly exceed P (up to 2^256 - 1).
+    private static func normalise32(_ a: Data) -> Data {
+        var fe = FieldElement(bytes: a)
+        fe.normalise()
+        return fe.toBytes()
+    }
+
+    /// The constant c = 2^32 + 977 as a 32-byte big-endian value.
+    /// Used by `reduce(...)` to fold high halves into low via
+    /// `2^256 ≡ 2^32 + 977 (mod P)`.
+    private static let c32Data: Data = {
+        var d = Data(count: 32)
+        // 2^32 + 977 = 0x1_0000_03D1
+        d[31] = 0xD1
+        d[30] = 0x03
+        d[29] = 0x00
+        d[28] = 0x00
+        d[27] = 0x01
+        return d
+    }()
+}

--- a/Sources/BSV/Primitives/KeyShares.swift
+++ b/Sources/BSV/Primitives/KeyShares.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// A bundle of Shamir Secret Sharing shares for a private key.
+///
+/// Each share is a `PointInFiniteField` — an (x, y) pair on a polynomial over
+/// GF(P). Any `threshold` shares are sufficient to reconstruct the original
+/// private key via Lagrange interpolation at x = 0.
+///
+/// `integrity` is the first 8 hex characters of the HASH160 of the compressed
+/// public key of the original private key, used to detect corruption or
+/// mismatched share bundles during reconstruction.
+///
+/// This type is interoperable with the ts-sdk and go-sdk share formats.
+public struct KeyShares: Sendable, Equatable {
+
+    /// The shares (polynomial points).
+    public let points: [PointInFiniteField]
+
+    /// The number of shares required to reconstruct the private key.
+    public let threshold: Int
+
+    /// Integrity tag derived from the source private key's public key hash.
+    public let integrity: String
+
+    // MARK: - Initialisation
+
+    public init(points: [PointInFiniteField], threshold: Int, integrity: String) {
+        self.points = points
+        self.threshold = threshold
+        self.integrity = integrity
+    }
+
+    // MARK: - Backup format
+
+    /// Serialise the share bundle to an array of strings in the form
+    /// `<base58(x)>.<base58(y)>.<threshold>.<integrity>`.
+    ///
+    /// Each element can be stored or transmitted independently. The format is
+    /// shared with ts-sdk and go-sdk.
+    public func toBackupFormat() -> [String] {
+        points.map { point in
+            "\(point.toString()).\(threshold).\(integrity)"
+        }
+    }
+
+    /// Parse a set of backup-format strings into a `KeyShares` bundle.
+    ///
+    /// All shares must report the same threshold and integrity tag.
+    ///
+    /// - Throws: `Shamir.Error.invalidShareFormat`, `.thresholdMismatch`, or
+    ///   `.integrityMismatch` if the strings are malformed or inconsistent.
+    public static func fromBackupFormat(_ shares: [String]) throws -> KeyShares {
+        var threshold = 0
+        var integrity = ""
+        var points: [PointInFiniteField] = []
+
+        for (idx, share) in shares.enumerated() {
+            let parts = share.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count == 4 else {
+                throw Shamir.Error.invalidShareFormat
+            }
+            guard let t = Int(parts[2]) else {
+                throw Shamir.Error.invalidShareFormat
+            }
+            let i = parts[3]
+            if idx != 0 {
+                guard threshold == t else {
+                    throw Shamir.Error.thresholdMismatch
+                }
+                guard integrity == i else {
+                    throw Shamir.Error.integrityMismatch
+                }
+            }
+            threshold = t
+            integrity = i
+            let point = try PointInFiniteField.fromString(parts[0] + "." + parts[1])
+            points.append(point)
+        }
+
+        return KeyShares(points: points, threshold: threshold, integrity: integrity)
+    }
+}

--- a/Sources/BSV/Primitives/PointInFiniteField.swift
+++ b/Sources/BSV/Primitives/PointInFiniteField.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// A point (x, y) in the secp256k1 finite field used by Shamir's Secret Sharing.
+///
+/// Both coordinates are scalars reduced modulo the field prime P. Used as evaluations
+/// of the Shamir polynomial — the constant term encodes a private key, and additional
+/// points are generated during splitting.
+///
+/// Matches the `PointInFiniteField` type in the ts-sdk and go-sdk so that share
+/// bundles are interoperable across SDKs.
+public struct PointInFiniteField: Sendable, Equatable {
+
+    /// The x coordinate as a 32-byte big-endian scalar (reduced mod P).
+    public let x: Data
+
+    /// The y coordinate as a 32-byte big-endian scalar (reduced mod P).
+    public let y: Data
+
+    // MARK: - Initialisation
+
+    /// Create a point from 32-byte big-endian scalars. Each coordinate is
+    /// reduced mod P on entry.
+    public init(x: Data, y: Data) {
+        self.x = FieldP.reduce(FieldP.pad(x))
+        self.y = FieldP.reduce(FieldP.pad(y))
+    }
+
+    // MARK: - Serialisation
+
+    /// Encode as `<base58(x)>.<base58(y)>` matching the ts-sdk format.
+    ///
+    /// The x and y coordinates are serialised as their minimal big-endian byte
+    /// representation (with leading zeros stripped) before base58 encoding.
+    public func toString() -> String {
+        Base58.encode(PointInFiniteField.minimalBytes(x)) + "." + Base58.encode(PointInFiniteField.minimalBytes(y))
+    }
+
+    /// Decode a point from `<base58(x)>.<base58(y)>` format.
+    /// - Throws: `Shamir.Error.invalidShareFormat` if the string is malformed or decoding fails.
+    public static func fromString(_ str: String) throws -> PointInFiniteField {
+        let parts = str.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 2 else {
+            throw Shamir.Error.invalidShareFormat
+        }
+        guard let xBytes = Base58.decode(parts[0]),
+              let yBytes = Base58.decode(parts[1]) else {
+            throw Shamir.Error.invalidShareFormat
+        }
+        return PointInFiniteField(x: xBytes, y: yBytes)
+    }
+
+    // MARK: - Helpers
+
+    /// Strip leading zero bytes, producing the minimal big-endian encoding.
+    /// A zero value becomes a single zero byte (matching ts-sdk BigNumber.toArray()).
+    static func minimalBytes(_ data: Data) -> Data {
+        var start = 0
+        while start < data.count - 1 && data[data.startIndex + start] == 0 {
+            start += 1
+        }
+        return Data(data[data.startIndex + start ..< data.endIndex])
+    }
+}

--- a/Sources/BSV/Primitives/Polynomial.swift
+++ b/Sources/BSV/Primitives/Polynomial.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// A polynomial over the secp256k1 finite field (mod P).
+///
+/// Used by Shamir's Secret Sharing to split a private key into shares. The
+/// constant term encodes the secret; all arithmetic is performed modulo the
+/// secp256k1 field prime P — matching the ts-sdk and go-sdk implementations so
+/// that share bundles are interoperable across SDKs.
+///
+/// The polynomial is represented by its defining points (not by explicit
+/// coefficients): given any `threshold` points, `valueAt(x:)` uses Lagrange
+/// interpolation to evaluate the unique polynomial of degree `threshold - 1`
+/// that passes through them.
+public struct Polynomial: Sendable, Equatable {
+
+    /// The points defining the polynomial.
+    public let points: [PointInFiniteField]
+
+    /// The number of points required to reconstruct the polynomial.
+    public let threshold: Int
+
+    // MARK: - Initialisation
+
+    /// Create a polynomial from a set of defining points.
+    ///
+    /// - Parameters:
+    ///   - points: Points lying on the polynomial.
+    ///   - threshold: Number of points required for reconstruction. Defaults
+    ///     to `points.count`.
+    public init(points: [PointInFiniteField], threshold: Int? = nil) {
+        self.points = points
+        self.threshold = threshold ?? points.count
+    }
+
+    /// Construct a polynomial of the given threshold whose constant term is a
+    /// private key.
+    ///
+    /// The first point is `(0, key)`. The remaining `threshold - 1` points are
+    /// generated from cryptographically secure randomness, producing a unique
+    /// polynomial of degree `threshold - 1` each time it is called.
+    ///
+    /// - Throws: `Shamir.Error.randomGenerationFailed` if secure random bytes
+    ///   cannot be obtained.
+    public static func fromPrivateKey(_ key: PrivateKey, threshold: Int) throws -> Polynomial {
+        var points: [PointInFiniteField] = []
+        let zero = Data(count: 32)
+        points.append(PointInFiniteField(x: zero, y: key.toBytes()))
+
+        for _ in 1..<threshold {
+            let rx = try Shamir.randomScalar()
+            let ry = try Shamir.randomScalar()
+            points.append(PointInFiniteField(x: rx, y: ry))
+        }
+        return Polynomial(points: points, threshold: threshold)
+    }
+
+    // MARK: - Evaluation
+
+    /// Evaluate the polynomial at `x` using Lagrange interpolation over GF(P).
+    ///
+    /// Only the first `threshold` points are used. The caller is responsible
+    /// for ensuring there are enough distinct points.
+    public func valueAt(_ x: Data) -> Data {
+        let xs = FieldP.pad(x)
+        var y = Data(count: 32) // y = 0
+        for i in 0..<threshold {
+            var term = FieldP.pad(points[i].y)
+            for j in 0..<threshold {
+                if i == j { continue }
+                let xj = FieldP.pad(points[j].x)
+                let xi = FieldP.pad(points[i].x)
+
+                let numerator = FieldP.sub(xs, xj)
+                let denominator = FieldP.sub(xi, xj)
+                let denominatorInverse = FieldP.inverse(denominator)
+
+                let fraction = FieldP.mul(numerator, denominatorInverse)
+                term = FieldP.mul(term, fraction)
+            }
+            y = FieldP.add(y, term)
+        }
+        return y
+    }
+}

--- a/Sources/BSV/Primitives/PrivateKey+Shamir.swift
+++ b/Sources/BSV/Primitives/PrivateKey+Shamir.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Security
+
+// MARK: - Shamir namespace
+
+/// Namespace for Shamir Secret Sharing errors and internal helpers.
+public enum Shamir {
+
+    public enum Error: Swift.Error, Equatable {
+        /// Threshold must be at least 2.
+        case thresholdTooLow
+        /// Total shares must be at least 2.
+        case totalSharesTooLow
+        /// Threshold cannot exceed total shares.
+        case thresholdExceedsTotal
+        /// Not enough shares supplied to reconstruct the key.
+        case insufficientShares(required: Int, got: Int)
+        /// Two shares had the same x coordinate.
+        case duplicateShare
+        /// A share string was malformed.
+        case invalidShareFormat
+        /// Shares did not agree on threshold.
+        case thresholdMismatch
+        /// Shares did not agree on integrity tag.
+        case integrityMismatch
+        /// Reconstructed private key failed the integrity check.
+        case integrityHashMismatch
+        /// The system RNG failed while generating a random scalar.
+        case randomGenerationFailed
+        /// Failed to produce a unique share x coordinate after repeated attempts.
+        case uniqueXGenerationFailed
+        /// Reconstructed value is not a valid private key (zero or >= N).
+        case invalidReconstructedKey
+    }
+
+    /// Generate a 32-byte cryptographically secure random value.
+    static func randomBytes(_ count: Int) throws -> Data {
+        var bytes = Data(count: count)
+        let status = bytes.withUnsafeMutableBytes { ptr in
+            SecRandomCopyBytes(kSecRandomDefault, count, ptr.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw Error.randomGenerationFailed
+        }
+        return bytes
+    }
+
+    /// Generate a random scalar reduced mod P.
+    static func randomScalar() throws -> Data {
+        let bytes = try randomBytes(32)
+        return FieldP.reduce(bytes)
+    }
+}
+
+// MARK: - PrivateKey Shamir extension
+
+public extension PrivateKey {
+
+    /// Split this private key into `totalShares` Shamir shares of which any
+    /// `threshold` can be used to reconstruct it.
+    ///
+    /// Matches ts-sdk's `toKeyShares` and go-sdk's `ToKeyShares`.
+    ///
+    /// - Parameters:
+    ///   - threshold: Minimum number of shares required to recover the key (≥ 2).
+    ///   - totalShares: Total number of shares to produce (≥ `threshold`, ≥ 2).
+    /// - Returns: A `KeyShares` bundle containing `totalShares` shares plus the
+    ///   integrity tag.
+    /// - Throws: `Shamir.Error` for invalid parameters or RNG failures.
+    func toKeyShares(threshold: Int, totalShares: Int) throws -> KeyShares {
+        if threshold < 2 { throw Shamir.Error.thresholdTooLow }
+        if totalShares < 2 { throw Shamir.Error.totalSharesTooLow }
+        if threshold > totalShares { throw Shamir.Error.thresholdExceedsTotal }
+
+        let poly = try Polynomial.fromPrivateKey(self, threshold: threshold)
+
+        var points: [PointInFiniteField] = []
+        var usedX = Set<Data>()
+
+        // x-coordinate generation: HMAC-SHA512 over a per-share counter seeded with
+        // 64 fresh random bytes, matching the ts-sdk/go-sdk strategy for deriving
+        // unique non-zero share x values.
+        let seed = try Shamir.randomBytes(64)
+        for i in 0..<totalShares {
+            var attempts: UInt32 = 0
+            var x: Data
+            repeat {
+                if attempts > 5 {
+                    throw Shamir.Error.uniqueXGenerationFailed
+                }
+                var counter = Data()
+                counter.append(contentsOf: withUnsafeBytes(of: UInt32(i).bigEndian, Array.init))
+                counter.append(contentsOf: withUnsafeBytes(of: attempts.bigEndian, Array.init))
+                counter.append(try Shamir.randomBytes(32))
+                let h = Digest.hmacSha512(data: counter, key: seed)
+                x = FieldP.reduce(h) // h is 64 bytes; reduce wide to 32 bytes mod P
+                attempts += 1
+            } while scalarIsZero(x) || usedX.contains(x)
+
+            usedX.insert(x)
+            let y = poly.valueAt(x)
+            points.append(PointInFiniteField(x: x, y: y))
+        }
+
+        let pubKey = PublicKey.fromPrivateKey(self)
+        let fullHashHex = pubKey.hash160().hex
+        let integrity = String(fullHashHex.prefix(8))
+        return KeyShares(points: points, threshold: threshold, integrity: integrity)
+    }
+
+    /// Alias for `toKeyShares(threshold:totalShares:)` matching the Swift naming
+    /// suggested in the Phase 8 task brief.
+    func split(threshold: Int, totalShares: Int) throws -> KeyShares {
+        try toKeyShares(threshold: threshold, totalShares: totalShares)
+    }
+
+    /// Serialise the private key as an array of backup share strings.
+    ///
+    /// Convenience wrapper over `toKeyShares(...).toBackupFormat()`.
+    func toBackupShares(threshold: Int, totalShares: Int) throws -> [String] {
+        try toKeyShares(threshold: threshold, totalShares: totalShares).toBackupFormat()
+    }
+
+    /// Reconstruct a private key from a set of Shamir shares using Lagrange
+    /// interpolation at x = 0.
+    ///
+    /// Matches ts-sdk's `fromKeyShares` and go-sdk's `PrivateKeyFromKeyShares`.
+    ///
+    /// - Parameter shares: The share bundle.
+    /// - Throws: `Shamir.Error` if too few shares are supplied, if any duplicate
+    ///   x coordinate is detected, or if the integrity check fails.
+    static func fromKeyShares(_ shares: KeyShares) throws -> PrivateKey {
+        if shares.threshold < 2 { throw Shamir.Error.thresholdTooLow }
+        if shares.points.count < shares.threshold {
+            throw Shamir.Error.insufficientShares(required: shares.threshold, got: shares.points.count)
+        }
+
+        // Check for duplicate x coordinates among the points used for reconstruction.
+        for i in 0..<shares.threshold {
+            for j in (i + 1)..<shares.threshold {
+                if shares.points[i].x == shares.points[j].x {
+                    throw Shamir.Error.duplicateShare
+                }
+            }
+        }
+
+        let poly = Polynomial(points: shares.points, threshold: shares.threshold)
+        let secret = poly.valueAt(Data(count: 32))
+        guard let privateKey = PrivateKey(data: secret) else {
+            throw Shamir.Error.invalidReconstructedKey
+        }
+
+        let pubKey = PublicKey.fromPrivateKey(privateKey)
+        let integrity = String(pubKey.hash160().hex.prefix(8))
+        guard integrity == shares.integrity else {
+            throw Shamir.Error.integrityHashMismatch
+        }
+        return privateKey
+    }
+
+    /// Reconstruct a private key from an array of backup share strings.
+    static func fromBackupShares(_ shares: [String]) throws -> PrivateKey {
+        let keyShares = try KeyShares.fromBackupFormat(shares)
+        return try fromKeyShares(keyShares)
+    }
+}

--- a/Sources/BSV/Wallet/CachedKeyDeriver.swift
+++ b/Sources/BSV/Wallet/CachedKeyDeriver.swift
@@ -5,6 +5,11 @@ import Foundation
 /// Useful when the same `(protocolID, keyID, counterparty)` triple is derived repeatedly,
 /// since BRC-42 derivation is dominated by an ECDH scalar multiplication.
 ///
+/// The cache is implemented as a dictionary plus a doubly-linked list, so
+/// every get / set / eviction is O(1). The previous implementation used an
+/// `Array<(String, CachedValue)>` with `firstIndex(where:) + remove + append`
+/// which degraded to O(n) on every call at the default `maxCacheSize = 1000`.
+///
 /// This class is thread-safe via a single internal lock.
 public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
     public let rootKey: PrivateKey
@@ -13,8 +18,23 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
     private let inner: KeyDeriver
     private let maxCacheSize: Int
     private let lock = NSLock()
-    // An ordered dictionary implemented as an Array<(key, value)> — newest at the end.
-    private var entries: [(String, CachedValue)] = []
+
+    // O(1) LRU: a dictionary maps keys to nodes, and a doubly-linked list
+    // tracks access order with head = least-recently-used, tail = most-recent.
+    private final class Node {
+        let key: String
+        var value: CachedValue
+        var prev: Node?
+        var next: Node?
+
+        init(key: String, value: CachedValue) {
+            self.key = key
+            self.value = value
+        }
+    }
+    private var lookup: [String: Node] = [:]
+    private var head: Node?   // least-recently-used
+    private var tail: Node?   // most-recently-used
 
     private enum CachedValue {
         case publicKey(PublicKey)
@@ -38,8 +58,11 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
         counterparty: WalletCounterparty,
         forSelf: Bool = false
     ) throws -> PublicKey {
-        let cacheKey = cacheKey("derivePublicKey", protocolID, keyID, counterparty, forSelf)
-        if case .publicKey(let cached) = get(cacheKey) {
+        let key = "derivePublicKey|" + encodeProtocol(protocolID)
+            + "|" + keyID
+            + "|" + encodeCounterparty(counterparty)
+            + "|" + (forSelf ? "1" : "0")
+        if case .publicKey(let cached) = get(key) {
             return cached
         }
         let result = try inner.derivePublicKey(
@@ -48,7 +71,7 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
             counterparty: counterparty,
             forSelf: forSelf
         )
-        set(cacheKey, .publicKey(result))
+        set(key, .publicKey(result))
         return result
     }
 
@@ -57,8 +80,10 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
         keyID: String,
         counterparty: WalletCounterparty
     ) throws -> PrivateKey {
-        let cacheKey = cacheKey("derivePrivateKey", protocolID, keyID, counterparty)
-        if case .privateKey(let cached) = get(cacheKey) {
+        let key = "derivePrivateKey|" + encodeProtocol(protocolID)
+            + "|" + keyID
+            + "|" + encodeCounterparty(counterparty)
+        if case .privateKey(let cached) = get(key) {
             return cached
         }
         let result = try inner.derivePrivateKey(
@@ -66,7 +91,7 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
             keyID: keyID,
             counterparty: counterparty
         )
-        set(cacheKey, .privateKey(result))
+        set(key, .privateKey(result))
         return result
     }
 
@@ -75,8 +100,10 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
         keyID: String,
         counterparty: WalletCounterparty
     ) throws -> SymmetricKey {
-        let cacheKey = cacheKey("deriveSymmetricKey", protocolID, keyID, counterparty)
-        if case .symmetricKey(let cached) = get(cacheKey) {
+        let key = "deriveSymmetricKey|" + encodeProtocol(protocolID)
+            + "|" + keyID
+            + "|" + encodeCounterparty(counterparty)
+        if case .symmetricKey(let cached) = get(key) {
             return cached
         }
         let result = try inner.deriveSymmetricKey(
@@ -84,17 +111,17 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
             keyID: keyID,
             counterparty: counterparty
         )
-        set(cacheKey, .symmetricKey(result))
+        set(key, .symmetricKey(result))
         return result
     }
 
     public func revealCounterpartySecret(counterparty: WalletCounterparty) throws -> Data {
-        let cacheKey = cacheKey("revealCounterpartySecret", counterparty)
-        if case .data(let cached) = get(cacheKey) {
+        let key = "revealCounterpartySecret|" + encodeCounterparty(counterparty)
+        if case .data(let cached) = get(key) {
             return cached
         }
         let result = try inner.revealCounterpartySecret(counterparty: counterparty)
-        set(cacheKey, .data(result))
+        set(key, .data(result))
         return result
     }
 
@@ -103,8 +130,10 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
         protocolID: WalletProtocol,
         keyID: String
     ) throws -> Data {
-        let cacheKey = cacheKey("revealSpecificSecret", counterparty, protocolID, keyID)
-        if case .data(let cached) = get(cacheKey) {
+        let key = "revealSpecificSecret|" + encodeCounterparty(counterparty)
+            + "|" + encodeProtocol(protocolID)
+            + "|" + keyID
+        if case .data(let cached) = get(key) {
             return cached
         }
         let result = try inner.revealSpecificSecret(
@@ -112,7 +141,7 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
             protocolID: protocolID,
             keyID: keyID
         )
-        set(cacheKey, .data(result))
+        set(key, .data(result))
         return result
     }
 
@@ -121,56 +150,71 @@ public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
     private func get(_ key: String) -> CachedValue? {
         lock.lock()
         defer { lock.unlock() }
-        if let index = entries.firstIndex(where: { $0.0 == key }) {
-            let entry = entries.remove(at: index)
-            entries.append(entry)
-            return entry.1
-        }
-        return nil
+        guard let node = lookup[key] else { return nil }
+        moveToTail(node)
+        return node.value
     }
 
     private func set(_ key: String, _ value: CachedValue) {
         lock.lock()
         defer { lock.unlock() }
-        if let index = entries.firstIndex(where: { $0.0 == key }) {
-            entries.remove(at: index)
+        if let node = lookup[key] {
+            node.value = value
+            moveToTail(node)
+            return
         }
-        entries.append((key, value))
-        while entries.count > maxCacheSize {
-            entries.removeFirst()
+        let node = Node(key: key, value: value)
+        lookup[key] = node
+        appendToTail(node)
+        if lookup.count > maxCacheSize, let victim = head {
+            removeNode(victim)
+            lookup.removeValue(forKey: victim.key)
         }
+    }
+
+    // MARK: - Linked-list helpers (O(1))
+
+    private func appendToTail(_ node: Node) {
+        node.prev = tail
+        node.next = nil
+        tail?.next = node
+        tail = node
+        if head == nil { head = node }
+    }
+
+    private func removeNode(_ node: Node) {
+        let prev = node.prev
+        let next = node.next
+        prev?.next = next
+        next?.prev = prev
+        if head === node { head = next }
+        if tail === node { tail = prev }
+        node.prev = nil
+        node.next = nil
+    }
+
+    private func moveToTail(_ node: Node) {
+        if tail === node { return }
+        removeNode(node)
+        appendToTail(node)
     }
 
     // MARK: - Key serialisation
 
-    private func cacheKey(_ method: String, _ args: Any...) -> String {
-        var parts: [String] = [method]
-        for arg in args {
-            parts.append(serialise(arg))
-        }
-        return parts.joined(separator: "|")
+    /// All cache-key inputs come from a fixed set of strongly typed values,
+    /// so encoding is exhaustive by construction — no `String(describing:)`
+    /// fallback, which previously risked silently aliasing distinct values
+    /// that happen to stringify identically.
+
+    private func encodeProtocol(_ proto: WalletProtocol) -> String {
+        "\(proto.securityLevel.rawValue):\(proto.protocol)"
     }
 
-    private func serialise(_ value: Any) -> String {
-        switch value {
-        case let pk as PublicKey:
-            return pk.hex
-        case let sk as PrivateKey:
-            return sk.hex
-        case let proto as WalletProtocol:
-            return "\(proto.securityLevel.rawValue):\(proto.protocol)"
-        case let cp as WalletCounterparty:
-            switch cp {
-            case .`self`: return "self"
-            case .anyone: return "anyone"
-            case .publicKey(let pk): return "pk:\(pk.hex)"
-            }
-        case let b as Bool:
-            return b ? "true" : "false"
-        case let s as String:
-            return s
-        default:
-            return String(describing: value)
+    private func encodeCounterparty(_ cp: WalletCounterparty) -> String {
+        switch cp {
+        case .`self`: return "self"
+        case .anyone: return "anyone"
+        case .publicKey(let pk): return "pk:\(pk.hex)"
         }
     }
 }

--- a/Sources/BSV/Wallet/CachedKeyDeriver.swift
+++ b/Sources/BSV/Wallet/CachedKeyDeriver.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// A `KeyDeriver` wrapper that memoises derivation results in an in-memory LRU cache.
+///
+/// Useful when the same `(protocolID, keyID, counterparty)` triple is derived repeatedly,
+/// since BRC-42 derivation is dominated by an ECDH scalar multiplication.
+///
+/// This class is thread-safe via a single internal lock.
+public final class CachedKeyDeriver: KeyDeriverAPI, @unchecked Sendable {
+    public let rootKey: PrivateKey
+    public let identityKey: PublicKey
+
+    private let inner: KeyDeriver
+    private let maxCacheSize: Int
+    private let lock = NSLock()
+    // An ordered dictionary implemented as an Array<(key, value)> — newest at the end.
+    private var entries: [(String, CachedValue)] = []
+
+    private enum CachedValue {
+        case publicKey(PublicKey)
+        case privateKey(PrivateKey)
+        case symmetricKey(SymmetricKey)
+        case data(Data)
+    }
+
+    public init(rootKey: PrivateKey, maxCacheSize: Int = 1000) {
+        self.rootKey = rootKey
+        self.identityKey = PublicKey.fromPrivateKey(rootKey)
+        self.inner = KeyDeriver(rootKey: rootKey)
+        self.maxCacheSize = max(1, maxCacheSize)
+    }
+
+    // MARK: - KeyDeriverAPI
+
+    public func derivePublicKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty,
+        forSelf: Bool = false
+    ) throws -> PublicKey {
+        let cacheKey = cacheKey("derivePublicKey", protocolID, keyID, counterparty, forSelf)
+        if case .publicKey(let cached) = get(cacheKey) {
+            return cached
+        }
+        let result = try inner.derivePublicKey(
+            protocolID: protocolID,
+            keyID: keyID,
+            counterparty: counterparty,
+            forSelf: forSelf
+        )
+        set(cacheKey, .publicKey(result))
+        return result
+    }
+
+    public func derivePrivateKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty
+    ) throws -> PrivateKey {
+        let cacheKey = cacheKey("derivePrivateKey", protocolID, keyID, counterparty)
+        if case .privateKey(let cached) = get(cacheKey) {
+            return cached
+        }
+        let result = try inner.derivePrivateKey(
+            protocolID: protocolID,
+            keyID: keyID,
+            counterparty: counterparty
+        )
+        set(cacheKey, .privateKey(result))
+        return result
+    }
+
+    public func deriveSymmetricKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty
+    ) throws -> SymmetricKey {
+        let cacheKey = cacheKey("deriveSymmetricKey", protocolID, keyID, counterparty)
+        if case .symmetricKey(let cached) = get(cacheKey) {
+            return cached
+        }
+        let result = try inner.deriveSymmetricKey(
+            protocolID: protocolID,
+            keyID: keyID,
+            counterparty: counterparty
+        )
+        set(cacheKey, .symmetricKey(result))
+        return result
+    }
+
+    public func revealCounterpartySecret(counterparty: WalletCounterparty) throws -> Data {
+        let cacheKey = cacheKey("revealCounterpartySecret", counterparty)
+        if case .data(let cached) = get(cacheKey) {
+            return cached
+        }
+        let result = try inner.revealCounterpartySecret(counterparty: counterparty)
+        set(cacheKey, .data(result))
+        return result
+    }
+
+    public func revealSpecificSecret(
+        counterparty: WalletCounterparty,
+        protocolID: WalletProtocol,
+        keyID: String
+    ) throws -> Data {
+        let cacheKey = cacheKey("revealSpecificSecret", counterparty, protocolID, keyID)
+        if case .data(let cached) = get(cacheKey) {
+            return cached
+        }
+        let result = try inner.revealSpecificSecret(
+            counterparty: counterparty,
+            protocolID: protocolID,
+            keyID: keyID
+        )
+        set(cacheKey, .data(result))
+        return result
+    }
+
+    // MARK: - Cache primitives
+
+    private func get(_ key: String) -> CachedValue? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let index = entries.firstIndex(where: { $0.0 == key }) {
+            let entry = entries.remove(at: index)
+            entries.append(entry)
+            return entry.1
+        }
+        return nil
+    }
+
+    private func set(_ key: String, _ value: CachedValue) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let index = entries.firstIndex(where: { $0.0 == key }) {
+            entries.remove(at: index)
+        }
+        entries.append((key, value))
+        while entries.count > maxCacheSize {
+            entries.removeFirst()
+        }
+    }
+
+    // MARK: - Key serialisation
+
+    private func cacheKey(_ method: String, _ args: Any...) -> String {
+        var parts: [String] = [method]
+        for arg in args {
+            parts.append(serialise(arg))
+        }
+        return parts.joined(separator: "|")
+    }
+
+    private func serialise(_ value: Any) -> String {
+        switch value {
+        case let pk as PublicKey:
+            return pk.hex
+        case let sk as PrivateKey:
+            return sk.hex
+        case let proto as WalletProtocol:
+            return "\(proto.securityLevel.rawValue):\(proto.protocol)"
+        case let cp as WalletCounterparty:
+            switch cp {
+            case .`self`: return "self"
+            case .anyone: return "anyone"
+            case .publicKey(let pk): return "pk:\(pk.hex)"
+            }
+        case let b as Bool:
+            return b ? "true" : "false"
+        case let s as String:
+            return s
+        default:
+            return String(describing: value)
+        }
+    }
+}

--- a/Sources/BSV/Wallet/KeyDeriver.swift
+++ b/Sources/BSV/Wallet/KeyDeriver.swift
@@ -77,7 +77,7 @@ public struct KeyDeriver: KeyDeriverAPI {
 
         if forSelf {
             // child = rootKey.deriveChild(counterparty, invoiceNumber).toPublicKey()
-            let childPriv = deriveChildPrivate(
+            let childPriv = try deriveChildPrivate(
                 priv: rootKey,
                 counterpartyPub: normalised,
                 invoiceNumber: invoiceNumber
@@ -85,7 +85,7 @@ public struct KeyDeriver: KeyDeriverAPI {
             return PublicKey.fromPrivateKey(childPriv)
         } else {
             // child = counterparty.deriveChild(rootKey, invoiceNumber)
-            return deriveChildPublic(
+            return try deriveChildPublic(
                 pub: normalised,
                 counterpartyPriv: rootKey,
                 invoiceNumber: invoiceNumber
@@ -100,7 +100,7 @@ public struct KeyDeriver: KeyDeriverAPI {
     ) throws -> PrivateKey {
         let normalised = normaliseCounterparty(counterparty)
         let invoiceNumber = try computeInvoiceNumber(protocolID: protocolID, keyID: keyID)
-        return deriveChildPrivate(
+        return try deriveChildPrivate(
             priv: rootKey,
             counterpartyPub: normalised,
             invoiceNumber: invoiceNumber
@@ -157,8 +157,8 @@ public struct KeyDeriver: KeyDeriverAPI {
 
         // Double-check to ensure not revealing the secret for self.
         let selfPub = PublicKey.fromPrivateKey(rootKey)
-        let selfDerived = deriveChildPrivate(priv: rootKey, counterpartyPub: selfPub, invoiceNumber: "test")
-        let counterpartyDerived = deriveChildPrivate(priv: rootKey, counterpartyPub: normalised, invoiceNumber: "test")
+        let selfDerived = try deriveChildPrivate(priv: rootKey, counterpartyPub: selfPub, invoiceNumber: "test")
+        let counterpartyDerived = try deriveChildPrivate(priv: rootKey, counterpartyPub: normalised, invoiceNumber: "test")
         guard selfDerived.data != counterpartyDerived.data else {
             throw WalletError.invalidParameter(
                 name: "counterparty",
@@ -190,11 +190,16 @@ public struct KeyDeriver: KeyDeriverAPI {
     /// counterparty's public key, and a UTF-8 invoice number.
     ///
     /// `childPriv = (rootPriv + HMAC-SHA256(invoice, compressed(rootPriv * counterpartyPub))) mod N`
+    ///
+    /// Throws `WalletError.unknown` if the derived scalar is invalid (zero
+    /// or >= curve order). Matches the BIP-32 / ExtendedKey behaviour: the
+    /// previous `?? priv` fallback silently returned the parent key, which
+    /// is a correctness and security bug.
     func deriveChildPrivate(
         priv: PrivateKey,
         counterpartyPub: PublicKey,
         invoiceNumber: String
-    ) -> PrivateKey {
+    ) throws -> PrivateKey {
         // Shared secret = priv * counterpartyPub
         let sharedPoint = counterpartyPub.point.multiplied(by: priv.data)
         let compressed = sharedPoint.compressed()
@@ -203,25 +208,35 @@ public struct KeyDeriver: KeyDeriverAPI {
         let child = scalarAddModN(hmac, priv.data)
         // A BRC-42 derivation can in theory produce the zero scalar; the ts-sdk
         // treats that as an invalid state. Guard against it.
-        return PrivateKey(data: child) ?? priv
+        guard let derived = PrivateKey(data: child) else {
+            throw WalletError.unknown("BRC-42 derivation produced invalid scalar")
+        }
+        return derived
     }
 
     /// Compute the BRC-42 child public key given the counterparty's public key,
     /// the counterparty's private key, and a UTF-8 invoice number.
     ///
     /// `childPub = rootPub + (HMAC-SHA256(invoice, compressed(counterpartyPriv * rootPub))) * G`
+    ///
+    /// Throws `WalletError.unknown` if the resulting point is the identity
+    /// at infinity — the caller must never silently fall back to the parent
+    /// key, which would collapse distinct derivations onto the same output.
     func deriveChildPublic(
         pub: PublicKey,
         counterpartyPriv: PrivateKey,
         invoiceNumber: String
-    ) -> PublicKey {
+    ) throws -> PublicKey {
         let sharedPoint = pub.point.multiplied(by: counterpartyPriv.data)
         let compressed = sharedPoint.compressed()
         let invoiceBytes = invoiceNumber.data(using: .utf8)!
         let hmac = Digest.hmacSha256(data: invoiceBytes, key: compressed)
         let hmacPoint = Secp256k1.G.multiplied(by: hmac)
         let childPoint = pub.point.adding(hmacPoint)
-        return PublicKey(point: childPoint) ?? pub
+        guard let derived = PublicKey(point: childPoint) else {
+            throw WalletError.unknown("BRC-42 derivation produced identity public key")
+        }
+        return derived
     }
 
     // MARK: - Helpers

--- a/Sources/BSV/Wallet/KeyDeriver.swift
+++ b/Sources/BSV/Wallet/KeyDeriver.swift
@@ -1,0 +1,299 @@
+import Foundation
+
+/// BRC-42 invoice-number key derivation.
+///
+/// Derives child private, public, and symmetric keys deterministically from a
+/// long-term root private key, a counterparty reference, a protocol identifier
+/// and a key identifier.
+///
+/// # Security note
+///
+/// BRC-42 is a lightweight deterministic key hierarchy, not an authenticated key
+/// exchange. It provides neither forward secrecy nor replay protection: a leak of
+/// the root key compromises every child key, past and future. Callers are
+/// expected to already possess and trust one another's long-term public keys.
+public protocol KeyDeriverAPI: Sendable {
+    /// The root private key used for all derivations.
+    var rootKey: PrivateKey { get }
+    /// The compressed public key of the root, serving as the deriver's identity.
+    var identityKey: PublicKey { get }
+
+    func derivePublicKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty,
+        forSelf: Bool
+    ) throws -> PublicKey
+
+    func derivePrivateKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty
+    ) throws -> PrivateKey
+
+    func deriveSymmetricKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty
+    ) throws -> SymmetricKey
+
+    func revealCounterpartySecret(counterparty: WalletCounterparty) throws -> Data
+
+    func revealSpecificSecret(
+        counterparty: WalletCounterparty,
+        protocolID: WalletProtocol,
+        keyID: String
+    ) throws -> Data
+}
+
+/// Stateless BRC-42 key deriver.
+public struct KeyDeriver: KeyDeriverAPI {
+    public let rootKey: PrivateKey
+    public let identityKey: PublicKey
+
+    public init(rootKey: PrivateKey) {
+        self.rootKey = rootKey
+        self.identityKey = PublicKey.fromPrivateKey(rootKey)
+    }
+
+    /// Construct a deriver whose root key is `1` (the BRC-42 "anyone" key).
+    public static var anyone: KeyDeriver {
+        // Scalar 1 padded to 32 bytes.
+        var one = Data(count: 32)
+        one[31] = 1
+        return KeyDeriver(rootKey: PrivateKey(data: one)!)
+    }
+
+    // MARK: - Derivation
+
+    public func derivePublicKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty,
+        forSelf: Bool = false
+    ) throws -> PublicKey {
+        let normalised = normaliseCounterparty(counterparty)
+        let invoiceNumber = try computeInvoiceNumber(protocolID: protocolID, keyID: keyID)
+
+        if forSelf {
+            // child = rootKey.deriveChild(counterparty, invoiceNumber).toPublicKey()
+            let childPriv = deriveChildPrivate(
+                priv: rootKey,
+                counterpartyPub: normalised,
+                invoiceNumber: invoiceNumber
+            )
+            return PublicKey.fromPrivateKey(childPriv)
+        } else {
+            // child = counterparty.deriveChild(rootKey, invoiceNumber)
+            return deriveChildPublic(
+                pub: normalised,
+                counterpartyPriv: rootKey,
+                invoiceNumber: invoiceNumber
+            )
+        }
+    }
+
+    public func derivePrivateKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty
+    ) throws -> PrivateKey {
+        let normalised = normaliseCounterparty(counterparty)
+        let invoiceNumber = try computeInvoiceNumber(protocolID: protocolID, keyID: keyID)
+        return deriveChildPrivate(
+            priv: rootKey,
+            counterpartyPub: normalised,
+            invoiceNumber: invoiceNumber
+        )
+    }
+
+    public func deriveSymmetricKey(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty
+    ) throws -> SymmetricKey {
+        // When counterparty is 'anyone', we use 1*G as the counterparty public key,
+        // which means the symmetric key becomes publicly derivable. This mirrors
+        // the behaviour of the ts-sdk and should only be used when public
+        // disclosure is intended.
+        let effectiveCounterparty: WalletCounterparty
+        switch counterparty {
+        case .anyone:
+            effectiveCounterparty = .publicKey(PublicKey.fromPrivateKey(KeyDeriver.anyone.rootKey))
+        default:
+            effectiveCounterparty = counterparty
+        }
+
+        let derivedPub = try derivePublicKey(
+            protocolID: protocolID,
+            keyID: keyID,
+            counterparty: effectiveCounterparty,
+            forSelf: false
+        )
+        let derivedPriv = try derivePrivateKey(
+            protocolID: protocolID,
+            keyID: keyID,
+            counterparty: effectiveCounterparty
+        )
+
+        // Shared secret x coordinate = derivedPub * derivedPriv.
+        let sharedPoint = derivedPub.point.multiplied(by: derivedPriv.data)
+        let (x, _) = sharedPoint.affine()
+        guard let symmetric = SymmetricKey(key: x.toBytes()) else {
+            throw WalletError.unknown("failed to derive symmetric key")
+        }
+        return symmetric
+    }
+
+    public func revealCounterpartySecret(counterparty: WalletCounterparty) throws -> Data {
+        if case .`self` = counterparty {
+            throw WalletError.invalidParameter(
+                name: "counterparty",
+                message: "counterparty secrets cannot be revealed for counterparty=self"
+            )
+        }
+
+        let normalised = normaliseCounterparty(counterparty)
+
+        // Double-check to ensure not revealing the secret for self.
+        let selfPub = PublicKey.fromPrivateKey(rootKey)
+        let selfDerived = deriveChildPrivate(priv: rootKey, counterpartyPub: selfPub, invoiceNumber: "test")
+        let counterpartyDerived = deriveChildPrivate(priv: rootKey, counterpartyPub: normalised, invoiceNumber: "test")
+        guard selfDerived.data != counterpartyDerived.data else {
+            throw WalletError.invalidParameter(
+                name: "counterparty",
+                message: "counterparty secrets cannot be revealed for counterparty=self"
+            )
+        }
+
+        // Compressed ECDH point.
+        let sharedPoint = normalised.point.multiplied(by: rootKey.data)
+        return sharedPoint.compressed()
+    }
+
+    public func revealSpecificSecret(
+        counterparty: WalletCounterparty,
+        protocolID: WalletProtocol,
+        keyID: String
+    ) throws -> Data {
+        let normalised = normaliseCounterparty(counterparty)
+        let sharedPoint = normalised.point.multiplied(by: rootKey.data)
+        let compressed = sharedPoint.compressed()
+        let invoiceNumber = try computeInvoiceNumber(protocolID: protocolID, keyID: keyID)
+        let invoiceBytes = invoiceNumber.data(using: .utf8)!
+        return Digest.hmacSha256(data: invoiceBytes, key: compressed)
+    }
+
+    // MARK: - Raw BRC-42 primitive
+
+    /// Compute the BRC-42 child private key given the root private key, the
+    /// counterparty's public key, and a UTF-8 invoice number.
+    ///
+    /// `childPriv = (rootPriv + HMAC-SHA256(invoice, compressed(rootPriv * counterpartyPub))) mod N`
+    func deriveChildPrivate(
+        priv: PrivateKey,
+        counterpartyPub: PublicKey,
+        invoiceNumber: String
+    ) -> PrivateKey {
+        // Shared secret = priv * counterpartyPub
+        let sharedPoint = counterpartyPub.point.multiplied(by: priv.data)
+        let compressed = sharedPoint.compressed()
+        let invoiceBytes = invoiceNumber.data(using: .utf8)!
+        let hmac = Digest.hmacSha256(data: invoiceBytes, key: compressed)
+        let child = scalarAddModN(hmac, priv.data)
+        // A BRC-42 derivation can in theory produce the zero scalar; the ts-sdk
+        // treats that as an invalid state. Guard against it.
+        return PrivateKey(data: child) ?? priv
+    }
+
+    /// Compute the BRC-42 child public key given the counterparty's public key,
+    /// the counterparty's private key, and a UTF-8 invoice number.
+    ///
+    /// `childPub = rootPub + (HMAC-SHA256(invoice, compressed(counterpartyPriv * rootPub))) * G`
+    func deriveChildPublic(
+        pub: PublicKey,
+        counterpartyPriv: PrivateKey,
+        invoiceNumber: String
+    ) -> PublicKey {
+        let sharedPoint = pub.point.multiplied(by: counterpartyPriv.data)
+        let compressed = sharedPoint.compressed()
+        let invoiceBytes = invoiceNumber.data(using: .utf8)!
+        let hmac = Digest.hmacSha256(data: invoiceBytes, key: compressed)
+        let hmacPoint = Secp256k1.G.multiplied(by: hmac)
+        let childPoint = pub.point.adding(hmacPoint)
+        return PublicKey(point: childPoint) ?? pub
+    }
+
+    // MARK: - Helpers
+
+    /// Normalise a counterparty reference to a concrete public key.
+    private func normaliseCounterparty(_ counterparty: WalletCounterparty) -> PublicKey {
+        switch counterparty {
+        case .`self`:
+            return PublicKey.fromPrivateKey(rootKey)
+        case .anyone:
+            return PublicKey.fromPrivateKey(KeyDeriver.anyone.rootKey)
+        case .publicKey(let pk):
+            return pk
+        }
+    }
+
+    /// Compute the BRC-43 invoice number string: `"<securityLevel>-<protocolName>-<keyID>"`.
+    ///
+    /// Enforces the same validation rules as the ts-sdk:
+    /// - protocol name must be 5–400 chars (with exception for specific linkage revelation)
+    /// - no consecutive spaces, only `[a-z0-9 ]`
+    /// - must not end with " protocol"
+    /// - key ID must be 1–800 chars
+    func computeInvoiceNumber(protocolID: WalletProtocol, keyID: String) throws -> String {
+        let securityLevel = protocolID.securityLevel
+        let protocolName = protocolID.protocol.lowercased().trimmingCharacters(in: .whitespaces)
+
+        guard !keyID.isEmpty else {
+            throw WalletError.invalidParameter(name: "keyID", message: "Key IDs must be 1 character or more")
+        }
+        guard keyID.count <= 800 else {
+            throw WalletError.invalidParameter(name: "keyID", message: "Key IDs must be 800 characters or less")
+        }
+
+        if protocolName.count > 400 {
+            if protocolName.hasPrefix("specific linkage revelation ") {
+                if protocolName.count > 430 {
+                    throw WalletError.invalidParameter(
+                        name: "protocolID",
+                        message: "Specific linkage revelation protocol names must be 430 characters or less"
+                    )
+                }
+            } else {
+                throw WalletError.invalidParameter(
+                    name: "protocolID",
+                    message: "Protocol names must be 400 characters or less"
+                )
+            }
+        }
+        guard protocolName.count >= 5 else {
+            throw WalletError.invalidParameter(name: "protocolID", message: "Protocol names must be 5 characters or more")
+        }
+        guard !protocolName.contains("  ") else {
+            throw WalletError.invalidParameter(
+                name: "protocolID",
+                message: "Protocol names cannot contain multiple consecutive spaces"
+            )
+        }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789 ")
+        guard protocolName.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            throw WalletError.invalidParameter(
+                name: "protocolID",
+                message: "Protocol names can only contain letters, numbers and spaces"
+            )
+        }
+        guard !protocolName.hasSuffix(" protocol") else {
+            throw WalletError.invalidParameter(
+                name: "protocolID",
+                message: "No need to end your protocol name with \" protocol\""
+            )
+        }
+
+        return "\(securityLevel.rawValue)-\(protocolName)-\(keyID)"
+    }
+}

--- a/Sources/BSV/Wallet/ProtoWallet.swift
+++ b/Sources/BSV/Wallet/ProtoWallet.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// A stateless, in-process BRC-100 wallet.
+///
+/// `ProtoWallet` owns a root `PrivateKey` and delegates all key derivation to
+/// a `KeyDeriverAPI` (by default `KeyDeriver`). It is the foundation for the
+/// local-backed `Wallet` implementation and for tests that do not need a
+/// full wallet application around them.
+///
+/// Like its ts-sdk counterpart, `ProtoWallet` does **not** provide permission
+/// prompts, persistent storage, or transaction construction. A wallet
+/// application is expected to wrap it.
+public struct ProtoWallet: WalletInterface {
+    public let keyDeriver: KeyDeriverAPI
+
+    public init(rootKey: PrivateKey) {
+        self.keyDeriver = KeyDeriver(rootKey: rootKey)
+    }
+
+    public init(keyDeriver: KeyDeriverAPI) {
+        self.keyDeriver = keyDeriver
+    }
+
+    // MARK: - Public key
+
+    public func getPublicKey(args: GetPublicKeyArgs) async throws -> GetPublicKeyResult {
+        if args.identityKey {
+            return GetPublicKeyResult(publicKey: keyDeriver.identityKey)
+        }
+        guard let enc = args.encryption else {
+            throw WalletError.invalidParameter(
+                name: "encryption",
+                message: "encryption args are required unless identityKey is true"
+            )
+        }
+        let pk = try keyDeriver.derivePublicKey(
+            protocolID: enc.protocolID,
+            keyID: enc.keyID,
+            counterparty: enc.counterparty,
+            forSelf: args.forSelf
+        )
+        return GetPublicKeyResult(publicKey: pk)
+    }
+
+    // MARK: - Symmetric encryption
+
+    public func encrypt(args: WalletEncryptArgs) async throws -> WalletEncryptResult {
+        let key = try keyDeriver.deriveSymmetricKey(
+            protocolID: args.encryption.protocolID,
+            keyID: args.encryption.keyID,
+            counterparty: args.encryption.counterparty
+        )
+        let ciphertext = try key.encrypt(args.plaintext)
+        return WalletEncryptResult(ciphertext: ciphertext)
+    }
+
+    public func decrypt(args: WalletDecryptArgs) async throws -> WalletDecryptResult {
+        let key = try keyDeriver.deriveSymmetricKey(
+            protocolID: args.encryption.protocolID,
+            keyID: args.encryption.keyID,
+            counterparty: args.encryption.counterparty
+        )
+        let plaintext = try key.decrypt(args.ciphertext)
+        return WalletDecryptResult(plaintext: plaintext)
+    }
+
+    // MARK: - HMAC
+
+    public func createHmac(args: CreateHmacArgs) async throws -> CreateHmacResult {
+        let key = try keyDeriver.deriveSymmetricKey(
+            protocolID: args.encryption.protocolID,
+            keyID: args.encryption.keyID,
+            counterparty: args.encryption.counterparty
+        )
+        let mac = Digest.hmacSha256(data: args.data, key: key.key)
+        return CreateHmacResult(hmac: mac)
+    }
+
+    public func verifyHmac(args: VerifyHmacArgs) async throws -> VerifyHmacResult {
+        let key = try keyDeriver.deriveSymmetricKey(
+            protocolID: args.encryption.protocolID,
+            keyID: args.encryption.keyID,
+            counterparty: args.encryption.counterparty
+        )
+        let expected = Digest.hmacSha256(data: args.data, key: key.key)
+        let ok = ConstantTime.equal(expected, args.hmac)
+        if !ok {
+            throw WalletError.invalidHmac
+        }
+        return VerifyHmacResult(valid: true)
+    }
+
+    // MARK: - Signatures
+
+    public func createSignature(args: CreateSignatureArgs) async throws -> CreateSignatureResult {
+        // Exactly one of data/hashToDirectlySign must be supplied.
+        let hash: Data
+        switch (args.data, args.hashToDirectlySign) {
+        case (let data?, nil):
+            hash = Digest.sha256(data)
+        case (nil, let directHash?):
+            guard directHash.count == 32 else {
+                throw WalletError.invalidParameter(
+                    name: "hashToDirectlySign",
+                    message: "must be exactly 32 bytes"
+                )
+            }
+            hash = directHash
+        default:
+            throw WalletError.invalidParameter(
+                name: "args",
+                message: "exactly one of data or hashToDirectlySign must be provided"
+            )
+        }
+
+        // NOTE: ts-sdk defaults `counterparty` to 'anyone' for signature creation,
+        // but we cannot distinguish "omitted" from "defaulted to .self" at the
+        // Swift call-site, so callers must explicitly pass `.anyone` when they
+        // intend that semantics. We honour whatever the caller set.
+        let child = try keyDeriver.derivePrivateKey(
+            protocolID: args.encryption.protocolID,
+            keyID: args.encryption.keyID,
+            counterparty: args.encryption.counterparty
+        )
+        guard let sig = child.sign(hash: hash) else {
+            throw WalletError.unknown("failed to sign")
+        }
+        return CreateSignatureResult(signature: sig.toDER())
+    }
+
+    public func verifySignature(args: VerifySignatureArgs) async throws -> VerifySignatureResult {
+        let hash: Data
+        switch (args.data, args.hashToDirectlyVerify) {
+        case (let data?, nil):
+            hash = Digest.sha256(data)
+        case (nil, let directHash?):
+            guard directHash.count == 32 else {
+                throw WalletError.invalidParameter(
+                    name: "hashToDirectlyVerify",
+                    message: "must be exactly 32 bytes"
+                )
+            }
+            hash = directHash
+        default:
+            throw WalletError.invalidParameter(
+                name: "args",
+                message: "exactly one of data or hashToDirectlyVerify must be provided"
+            )
+        }
+
+        let pub = try keyDeriver.derivePublicKey(
+            protocolID: args.encryption.protocolID,
+            keyID: args.encryption.keyID,
+            counterparty: args.encryption.counterparty,
+            forSelf: args.forSelf
+        )
+        guard let sig = Signature.fromDER(args.signature) else {
+            throw WalletError.invalidSignature
+        }
+        let ok = pub.verify(hash: hash, signature: sig)
+        if !ok {
+            throw WalletError.invalidSignature
+        }
+        return VerifySignatureResult(valid: true)
+    }
+
+    // MARK: - Linkage revelation
+
+    public func revealCounterpartyKeyLinkage(
+        args: RevealCounterpartyKeyLinkageArgs
+    ) async throws -> RevealCounterpartyKeyLinkageResult {
+        // BRC-72 counterparty linkage revelation requires the prover to sign
+        // the linkage with a Schnorr proof binding the shared secret to the
+        // verifier. The Swift SDK does not yet implement Schnorr, so we
+        // throw `unsupportedAction` until the primitive lands.
+        throw WalletError.unsupportedAction(
+            "revealCounterpartyKeyLinkage is not yet implemented in the Swift SDK (requires Schnorr proofs)"
+        )
+    }
+
+    public func revealSpecificKeyLinkage(
+        args: RevealSpecificKeyLinkageArgs
+    ) async throws -> RevealSpecificKeyLinkageResult {
+        let secret = try keyDeriver.revealSpecificSecret(
+            counterparty: args.counterparty,
+            protocolID: args.protocolID,
+            keyID: args.keyID
+        )
+
+        // Encrypt the linkage under a symmetric key shared with the verifier.
+        let verifierCp = WalletCounterparty.publicKey(args.verifier)
+        let symmetric = try keyDeriver.deriveSymmetricKey(
+            protocolID: args.protocolID,
+            keyID: args.keyID,
+            counterparty: verifierCp
+        )
+        let encryptedLinkage = try symmetric.encrypt(secret)
+
+        return RevealSpecificKeyLinkageResult(
+            prover: keyDeriver.identityKey,
+            verifier: args.verifier,
+            counterparty: args.counterparty,
+            protocolID: args.protocolID,
+            keyID: args.keyID,
+            encryptedLinkage: encryptedLinkage,
+            encryptedLinkageProof: Data(),
+            proofType: 0
+        )
+    }
+}
+
+/// Byte helpers.
+enum ConstantTime {
+    /// Constant-time comparison of two byte buffers.
+    static func equal(_ a: Data, _ b: Data) -> Bool {
+        guard a.count == b.count else { return false }
+        var diff: UInt8 = 0
+        for i in 0..<a.count {
+            diff |= a[a.startIndex + i] ^ b[b.startIndex + i]
+        }
+        return diff == 0
+    }
+}

--- a/Sources/BSV/Wallet/ProtoWallet.swift
+++ b/Sources/BSV/Wallet/ProtoWallet.swift
@@ -208,16 +208,3 @@ public struct ProtoWallet: WalletInterface {
         )
     }
 }
-
-/// Byte helpers.
-enum ConstantTime {
-    /// Constant-time comparison of two byte buffers.
-    static func equal(_ a: Data, _ b: Data) -> Bool {
-        guard a.count == b.count else { return false }
-        var diff: UInt8 = 0
-        for i in 0..<a.count {
-            diff |= a[a.startIndex + i] ^ b[b.startIndex + i]
-        }
-        return diff == 0
-    }
-}

--- a/Sources/BSV/Wallet/WalletClient.swift
+++ b/Sources/BSV/Wallet/WalletClient.swift
@@ -118,12 +118,14 @@ public struct WalletClient: WalletInterface {
     public func revealCounterpartyKeyLinkage(
         args: RevealCounterpartyKeyLinkageArgs
     ) async throws -> RevealCounterpartyKeyLinkageResult {
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             "counterparty": args.counterparty.hex,
             "verifier": args.verifier.hex,
-            "privileged": args.privileged,
-            "privilegedReason": args.privilegedReason as Any
+            "privileged": args.privileged
         ]
+        if let reason = args.privilegedReason {
+            payload["privilegedReason"] = reason
+        }
         let response = try await call("revealCounterpartyKeyLinkage", payload: payload)
         guard
             let proverHex = response["prover"] as? String,

--- a/Sources/BSV/Wallet/WalletClient.swift
+++ b/Sources/BSV/Wallet/WalletClient.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+/// A BRC-100 wallet client that forwards calls to a remote wallet over a `WalletSubstrate`.
+///
+/// `WalletClient` is the counterpart to `ProtoWallet`: it implements the same
+/// `WalletInterface` but instead of doing the cryptography locally it encodes
+/// each call as JSON, sends it through a substrate, and decodes the response.
+///
+/// This mirrors the ts-sdk `WalletClient` class. Byte fields in the JSON
+/// wire format are encoded as an array of numbers 0…255 to stay compatible
+/// with the ts-sdk substrates.
+public struct WalletClient: WalletInterface {
+    public let substrate: WalletSubstrate
+    public let originator: String?
+
+    public init(substrate: WalletSubstrate, originator: String? = nil) {
+        self.substrate = substrate
+        self.originator = originator
+    }
+
+    // MARK: - Identity / derivation
+
+    public func getPublicKey(args: GetPublicKeyArgs) async throws -> GetPublicKeyResult {
+        var payload: [String: Any] = [
+            "identityKey": args.identityKey,
+            "forSelf": args.forSelf
+        ]
+        if let enc = args.encryption {
+            payload.merge(Self.encodeEncryptionArgs(enc)) { _, new in new }
+        }
+        let response = try await call("getPublicKey", payload: payload)
+        guard let hex = response["publicKey"] as? String,
+              let pk = PublicKey(hex: hex) else {
+            throw WalletError.unknown("invalid publicKey in getPublicKey response")
+        }
+        return GetPublicKeyResult(publicKey: pk)
+    }
+
+    // MARK: - Encryption
+
+    public func encrypt(args: WalletEncryptArgs) async throws -> WalletEncryptResult {
+        var payload = Self.encodeEncryptionArgs(args.encryption)
+        payload["plaintext"] = Self.encodeBytes(args.plaintext)
+        let response = try await call("encrypt", payload: payload)
+        guard let ct = Self.decodeBytes(response["ciphertext"]) else {
+            throw WalletError.unknown("missing ciphertext in encrypt response")
+        }
+        return WalletEncryptResult(ciphertext: ct)
+    }
+
+    public func decrypt(args: WalletDecryptArgs) async throws -> WalletDecryptResult {
+        var payload = Self.encodeEncryptionArgs(args.encryption)
+        payload["ciphertext"] = Self.encodeBytes(args.ciphertext)
+        let response = try await call("decrypt", payload: payload)
+        guard let pt = Self.decodeBytes(response["plaintext"]) else {
+            throw WalletError.unknown("missing plaintext in decrypt response")
+        }
+        return WalletDecryptResult(plaintext: pt)
+    }
+
+    // MARK: - HMAC
+
+    public func createHmac(args: CreateHmacArgs) async throws -> CreateHmacResult {
+        var payload = Self.encodeEncryptionArgs(args.encryption)
+        payload["data"] = Self.encodeBytes(args.data)
+        let response = try await call("createHmac", payload: payload)
+        guard let mac = Self.decodeBytes(response["hmac"]) else {
+            throw WalletError.unknown("missing hmac in createHmac response")
+        }
+        return CreateHmacResult(hmac: mac)
+    }
+
+    public func verifyHmac(args: VerifyHmacArgs) async throws -> VerifyHmacResult {
+        var payload = Self.encodeEncryptionArgs(args.encryption)
+        payload["data"] = Self.encodeBytes(args.data)
+        payload["hmac"] = Self.encodeBytes(args.hmac)
+        let response = try await call("verifyHmac", payload: payload)
+        let valid = response["valid"] as? Bool ?? false
+        if !valid { throw WalletError.invalidHmac }
+        return VerifyHmacResult(valid: true)
+    }
+
+    // MARK: - Signature
+
+    public func createSignature(args: CreateSignatureArgs) async throws -> CreateSignatureResult {
+        var payload = Self.encodeEncryptionArgs(args.encryption)
+        if let data = args.data {
+            payload["data"] = Self.encodeBytes(data)
+        }
+        if let hash = args.hashToDirectlySign {
+            payload["hashToDirectlySign"] = Self.encodeBytes(hash)
+        }
+        let response = try await call("createSignature", payload: payload)
+        guard let sig = Self.decodeBytes(response["signature"]) else {
+            throw WalletError.unknown("missing signature in createSignature response")
+        }
+        return CreateSignatureResult(signature: sig)
+    }
+
+    public func verifySignature(args: VerifySignatureArgs) async throws -> VerifySignatureResult {
+        var payload = Self.encodeEncryptionArgs(args.encryption)
+        payload["signature"] = Self.encodeBytes(args.signature)
+        payload["forSelf"] = args.forSelf
+        if let data = args.data {
+            payload["data"] = Self.encodeBytes(data)
+        }
+        if let hash = args.hashToDirectlyVerify {
+            payload["hashToDirectlyVerify"] = Self.encodeBytes(hash)
+        }
+        let response = try await call("verifySignature", payload: payload)
+        let valid = response["valid"] as? Bool ?? false
+        if !valid { throw WalletError.invalidSignature }
+        return VerifySignatureResult(valid: true)
+    }
+
+    // MARK: - Linkage revelation
+
+    public func revealCounterpartyKeyLinkage(
+        args: RevealCounterpartyKeyLinkageArgs
+    ) async throws -> RevealCounterpartyKeyLinkageResult {
+        let payload: [String: Any] = [
+            "counterparty": args.counterparty.hex,
+            "verifier": args.verifier.hex,
+            "privileged": args.privileged,
+            "privilegedReason": args.privilegedReason as Any
+        ]
+        let response = try await call("revealCounterpartyKeyLinkage", payload: payload)
+        guard
+            let proverHex = response["prover"] as? String,
+            let prover = PublicKey(hex: proverHex),
+            let verifierHex = response["verifier"] as? String,
+            let verifier = PublicKey(hex: verifierHex),
+            let cpHex = response["counterparty"] as? String,
+            let cp = PublicKey(hex: cpHex),
+            let time = response["revelationTime"] as? String,
+            let encryptedLinkage = Self.decodeBytes(response["encryptedLinkage"]),
+            let proof = Self.decodeBytes(response["encryptedLinkageProof"])
+        else {
+            throw WalletError.unknown("invalid revealCounterpartyKeyLinkage response")
+        }
+        return RevealCounterpartyKeyLinkageResult(
+            prover: prover,
+            verifier: verifier,
+            counterparty: cp,
+            revelationTime: time,
+            encryptedLinkage: encryptedLinkage,
+            encryptedLinkageProof: proof
+        )
+    }
+
+    public func revealSpecificKeyLinkage(
+        args: RevealSpecificKeyLinkageArgs
+    ) async throws -> RevealSpecificKeyLinkageResult {
+        var payload: [String: Any] = [
+            "counterparty": Self.encodeCounterparty(args.counterparty),
+            "verifier": args.verifier.hex,
+            "protocolID": [args.protocolID.securityLevel.rawValue, args.protocolID.protocol] as [Any],
+            "keyID": args.keyID,
+            "privileged": args.privileged
+        ]
+        if let reason = args.privilegedReason {
+            payload["privilegedReason"] = reason
+        }
+        let response = try await call("revealSpecificKeyLinkage", payload: payload)
+        guard
+            let proverHex = response["prover"] as? String,
+            let prover = PublicKey(hex: proverHex),
+            let verifierHex = response["verifier"] as? String,
+            let verifier = PublicKey(hex: verifierHex),
+            let encryptedLinkage = Self.decodeBytes(response["encryptedLinkage"]),
+            let proof = Self.decodeBytes(response["encryptedLinkageProof"]),
+            let proofType = response["proofType"] as? Int
+        else {
+            throw WalletError.unknown("invalid revealSpecificKeyLinkage response")
+        }
+        return RevealSpecificKeyLinkageResult(
+            prover: prover,
+            verifier: verifier,
+            counterparty: args.counterparty,
+            protocolID: args.protocolID,
+            keyID: args.keyID,
+            encryptedLinkage: encryptedLinkage,
+            encryptedLinkageProof: proof,
+            proofType: UInt8(truncatingIfNeeded: proofType)
+        )
+    }
+
+    // MARK: - Internal helpers
+
+    /// POST a JSON payload to the substrate and decode the response as a JSON object.
+    private func call(_ method: String, payload: [String: Any]) async throws -> [String: Any] {
+        let body = try JSONSerialization.data(withJSONObject: payload, options: [])
+        let responseData = try await substrate.invoke(method: method, body: body, originator: originator)
+        if responseData.isEmpty {
+            return [:]
+        }
+        guard let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+            throw WalletError.unknown("\(method) response was not a JSON object")
+        }
+        return json
+    }
+
+    /// Encode the shared `WalletEncryptionArgs` fields into a BRC-100 payload.
+    static func encodeEncryptionArgs(_ args: WalletEncryptionArgs) -> [String: Any] {
+        var payload: [String: Any] = [
+            "protocolID": [args.protocolID.securityLevel.rawValue, args.protocolID.protocol] as [Any],
+            "keyID": args.keyID,
+            "counterparty": encodeCounterparty(args.counterparty),
+            "privileged": args.privileged,
+            "seekPermission": args.seekPermission
+        ]
+        if let reason = args.privilegedReason {
+            payload["privilegedReason"] = reason
+        }
+        return payload
+    }
+
+    static func encodeCounterparty(_ counterparty: WalletCounterparty) -> Any {
+        switch counterparty {
+        case .`self`: return "self"
+        case .anyone: return "anyone"
+        case .publicKey(let pk): return pk.hex
+        }
+    }
+
+    /// Encode raw bytes as an array of byte-valued integers (ts-sdk wire format).
+    static func encodeBytes(_ data: Data) -> [UInt8] {
+        Array(data)
+    }
+
+    /// Decode the ts-sdk wire format for bytes: either an array of integers or a hex string.
+    static func decodeBytes(_ value: Any?) -> Data? {
+        if let bytes = value as? [UInt8] {
+            return Data(bytes)
+        }
+        if let ints = value as? [Int] {
+            return Data(ints.map { UInt8(truncatingIfNeeded: $0) })
+        }
+        if let numbers = value as? [NSNumber] {
+            return Data(numbers.map { UInt8(truncatingIfNeeded: $0.intValue) })
+        }
+        if let hex = value as? String {
+            return Data(hex: hex)
+        }
+        return nil
+    }
+}

--- a/Sources/BSV/Wallet/WalletError.swift
+++ b/Sources/BSV/Wallet/WalletError.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Errors thrown by wallet operations.
+///
+/// Mirrors the ts-sdk `WERR_*` hierarchy. The underlying `code` values match
+/// the ts-sdk `walletErrors` enum so wire protocols can round-trip the code.
+public enum WalletError: Error, Equatable, Sendable {
+    case unknown(String)
+    case unsupportedAction(String)
+    case invalidHmac
+    case invalidSignature
+    case reviewActions(message: String)
+    case invalidParameter(name: String, message: String)
+    case insufficientFunds(totalSatoshisNeeded: Int, moreSatoshisNeeded: Int)
+    case keyDeriverUnavailable
+    case transportFailure(String)
+
+    /// Numeric error code matching the ts-sdk `walletErrors` enum.
+    public var code: Int {
+        switch self {
+        case .unknown, .keyDeriverUnavailable, .transportFailure: return 1
+        case .unsupportedAction: return 2
+        case .invalidHmac: return 3
+        case .invalidSignature: return 4
+        case .reviewActions: return 5
+        case .invalidParameter: return 6
+        case .insufficientFunds: return 7
+        }
+    }
+
+    /// A human-readable name matching the ts-sdk `WERR_*` class names.
+    public var name: String {
+        switch self {
+        case .unknown, .keyDeriverUnavailable, .transportFailure: return "WERR_UNKNOWN"
+        case .unsupportedAction: return "WERR_UNSUPPORTED_ACTION"
+        case .invalidHmac: return "WERR_INVALID_HMAC"
+        case .invalidSignature: return "WERR_INVALID_SIGNATURE"
+        case .reviewActions: return "WERR_REVIEW_ACTIONS"
+        case .invalidParameter: return "WERR_INVALID_PARAMETER"
+        case .insufficientFunds: return "WERR_INSUFFICIENT_FUNDS"
+        }
+    }
+}
+
+extension WalletError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unknown(let message): return message
+        case .unsupportedAction(let message): return message
+        case .invalidHmac: return "HMAC is not valid"
+        case .invalidSignature: return "Signature is not valid"
+        case .reviewActions(let message): return message
+        case .invalidParameter(let name, let message): return "Invalid parameter \(name): \(message)"
+        case .insufficientFunds(let needed, let more):
+            return "Insufficient funds: need \(needed) sats, short \(more) sats"
+        case .keyDeriverUnavailable: return "keyDeriver is undefined"
+        case .transportFailure(let message): return "Transport failure: \(message)"
+        }
+    }
+}

--- a/Sources/BSV/Wallet/WalletInterface.swift
+++ b/Sources/BSV/Wallet/WalletInterface.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The BRC-100 wallet surface used by wallet applications.
+///
+/// This mirrors the ts-sdk `WalletInterface` type, restricted to the core
+/// cryptographic methods that a local `ProtoWallet` or a remote `WalletClient`
+/// can fulfil without additional infrastructure (transaction building,
+/// certificate storage, and permission management are layered on top).
+///
+/// Implementations must be `Sendable` so they can be shared across actors.
+public protocol WalletInterface: Sendable {
+    /// Return the identity public key, or a BRC-42 derived public key.
+    func getPublicKey(args: GetPublicKeyArgs) async throws -> GetPublicKeyResult
+
+    /// Encrypt with a derived symmetric key. Output is the raw AES-GCM ciphertext.
+    func encrypt(args: WalletEncryptArgs) async throws -> WalletEncryptResult
+
+    /// Decrypt with a derived symmetric key.
+    func decrypt(args: WalletDecryptArgs) async throws -> WalletDecryptResult
+
+    /// Compute an HMAC-SHA256 with a derived symmetric key.
+    func createHmac(args: CreateHmacArgs) async throws -> CreateHmacResult
+
+    /// Verify an HMAC-SHA256 with a derived symmetric key.
+    func verifyHmac(args: VerifyHmacArgs) async throws -> VerifyHmacResult
+
+    /// Produce a DER-encoded ECDSA signature using a derived private key.
+    ///
+    /// Exactly one of `data` or `hashToDirectlySign` must be supplied.
+    func createSignature(args: CreateSignatureArgs) async throws -> CreateSignatureResult
+
+    /// Verify a DER-encoded ECDSA signature.
+    func verifySignature(args: VerifySignatureArgs) async throws -> VerifySignatureResult
+
+    /// Reveal the counterparty-level key linkage for BRC-72 audit purposes.
+    func revealCounterpartyKeyLinkage(
+        args: RevealCounterpartyKeyLinkageArgs
+    ) async throws -> RevealCounterpartyKeyLinkageResult
+
+    /// Reveal a specific key linkage for BRC-72 audit purposes.
+    func revealSpecificKeyLinkage(
+        args: RevealSpecificKeyLinkageArgs
+    ) async throws -> RevealSpecificKeyLinkageResult
+}

--- a/Sources/BSV/Wallet/WalletTypes.swift
+++ b/Sources/BSV/Wallet/WalletTypes.swift
@@ -232,6 +232,22 @@ public struct RevealCounterpartyKeyLinkageResult: Sendable, Equatable {
     public let revelationTime: String
     public let encryptedLinkage: Data
     public let encryptedLinkageProof: Data
+
+    public init(
+        prover: PublicKey,
+        verifier: PublicKey,
+        counterparty: PublicKey,
+        revelationTime: String,
+        encryptedLinkage: Data,
+        encryptedLinkageProof: Data
+    ) {
+        self.prover = prover
+        self.verifier = verifier
+        self.counterparty = counterparty
+        self.revelationTime = revelationTime
+        self.encryptedLinkage = encryptedLinkage
+        self.encryptedLinkageProof = encryptedLinkageProof
+    }
 }
 
 public struct RevealSpecificKeyLinkageResult: Sendable, Equatable {
@@ -243,4 +259,24 @@ public struct RevealSpecificKeyLinkageResult: Sendable, Equatable {
     public let encryptedLinkage: Data
     public let encryptedLinkageProof: Data
     public let proofType: UInt8
+
+    public init(
+        prover: PublicKey,
+        verifier: PublicKey,
+        counterparty: WalletCounterparty,
+        protocolID: WalletProtocol,
+        keyID: String,
+        encryptedLinkage: Data,
+        encryptedLinkageProof: Data,
+        proofType: UInt8
+    ) {
+        self.prover = prover
+        self.verifier = verifier
+        self.counterparty = counterparty
+        self.protocolID = protocolID
+        self.keyID = keyID
+        self.encryptedLinkage = encryptedLinkage
+        self.encryptedLinkageProof = encryptedLinkageProof
+        self.proofType = proofType
+    }
 }

--- a/Sources/BSV/Wallet/WalletTypes.swift
+++ b/Sources/BSV/Wallet/WalletTypes.swift
@@ -1,0 +1,246 @@
+import Foundation
+
+// MARK: - BRC-100 scalar type aliases
+
+/// Security level for protocols per BRC-43.
+/// - 0 = silent (no user interaction)
+/// - 1 = requires approval per application
+/// - 2 = requires approval per counterparty per application
+public enum SecurityLevel: Int, Sendable, Codable {
+    case silent = 0
+    case app = 1
+    case counterparty = 2
+}
+
+/// A BRC-43 wallet protocol identifier: a pair of (security level, protocol name).
+public struct WalletProtocol: Sendable, Equatable {
+    public let securityLevel: SecurityLevel
+    public let `protocol`: String
+
+    public init(securityLevel: SecurityLevel, protocol: String) {
+        self.securityLevel = securityLevel
+        self.`protocol` = `protocol`
+    }
+}
+
+/// A BRC-42 counterparty reference: either a specific public key, the current identity ("self"),
+/// or the publicly-known "anyone" key (1*G).
+public enum WalletCounterparty: Sendable, Equatable {
+    case `self`
+    case anyone
+    case publicKey(PublicKey)
+
+    /// Construct from a hex-encoded compressed public key.
+    public static func hex(_ hex: String) -> WalletCounterparty? {
+        guard let pk = PublicKey(hex: hex) else { return nil }
+        return .publicKey(pk)
+    }
+}
+
+// MARK: - Common BRC-100 argument shapes
+
+/// Shared encryption-argument fields reused by encrypt/decrypt/hmac/signature/getPublicKey.
+public struct WalletEncryptionArgs: Sendable, Equatable {
+    public var protocolID: WalletProtocol
+    public var keyID: String
+    public var counterparty: WalletCounterparty
+    public var privileged: Bool
+    public var privilegedReason: String?
+    public var seekPermission: Bool
+
+    public init(
+        protocolID: WalletProtocol,
+        keyID: String,
+        counterparty: WalletCounterparty = .`self`,
+        privileged: Bool = false,
+        privilegedReason: String? = nil,
+        seekPermission: Bool = true
+    ) {
+        self.protocolID = protocolID
+        self.keyID = keyID
+        self.counterparty = counterparty
+        self.privileged = privileged
+        self.privilegedReason = privilegedReason
+        self.seekPermission = seekPermission
+    }
+}
+
+/// Arguments for `getPublicKey`.
+///
+/// When `identityKey` is `true`, the root identity key is returned and
+/// `encryption` is ignored. Otherwise `encryption` must be supplied.
+public struct GetPublicKeyArgs: Sendable {
+    public var identityKey: Bool
+    public var forSelf: Bool
+    public var encryption: WalletEncryptionArgs?
+
+    public init(identityKey: Bool = false, forSelf: Bool = false, encryption: WalletEncryptionArgs? = nil) {
+        self.identityKey = identityKey
+        self.forSelf = forSelf
+        self.encryption = encryption
+    }
+}
+
+public struct GetPublicKeyResult: Sendable, Equatable {
+    public let publicKey: PublicKey
+    public init(publicKey: PublicKey) { self.publicKey = publicKey }
+}
+
+public struct WalletEncryptArgs: Sendable {
+    public var encryption: WalletEncryptionArgs
+    public var plaintext: Data
+    public init(encryption: WalletEncryptionArgs, plaintext: Data) {
+        self.encryption = encryption
+        self.plaintext = plaintext
+    }
+}
+
+public struct WalletEncryptResult: Sendable, Equatable {
+    public let ciphertext: Data
+    public init(ciphertext: Data) { self.ciphertext = ciphertext }
+}
+
+public struct WalletDecryptArgs: Sendable {
+    public var encryption: WalletEncryptionArgs
+    public var ciphertext: Data
+    public init(encryption: WalletEncryptionArgs, ciphertext: Data) {
+        self.encryption = encryption
+        self.ciphertext = ciphertext
+    }
+}
+
+public struct WalletDecryptResult: Sendable, Equatable {
+    public let plaintext: Data
+    public init(plaintext: Data) { self.plaintext = plaintext }
+}
+
+public struct CreateHmacArgs: Sendable {
+    public var encryption: WalletEncryptionArgs
+    public var data: Data
+    public init(encryption: WalletEncryptionArgs, data: Data) {
+        self.encryption = encryption
+        self.data = data
+    }
+}
+
+public struct CreateHmacResult: Sendable, Equatable {
+    public let hmac: Data
+    public init(hmac: Data) { self.hmac = hmac }
+}
+
+public struct VerifyHmacArgs: Sendable {
+    public var encryption: WalletEncryptionArgs
+    public var data: Data
+    public var hmac: Data
+    public init(encryption: WalletEncryptionArgs, data: Data, hmac: Data) {
+        self.encryption = encryption
+        self.data = data
+        self.hmac = hmac
+    }
+}
+
+public struct VerifyHmacResult: Sendable, Equatable {
+    public let valid: Bool
+    public init(valid: Bool) { self.valid = valid }
+}
+
+public struct CreateSignatureArgs: Sendable {
+    public var encryption: WalletEncryptionArgs
+    public var data: Data?
+    public var hashToDirectlySign: Data?
+    public init(encryption: WalletEncryptionArgs, data: Data? = nil, hashToDirectlySign: Data? = nil) {
+        self.encryption = encryption
+        self.data = data
+        self.hashToDirectlySign = hashToDirectlySign
+    }
+}
+
+public struct CreateSignatureResult: Sendable, Equatable {
+    public let signature: Data
+    public init(signature: Data) { self.signature = signature }
+}
+
+public struct VerifySignatureArgs: Sendable {
+    public var encryption: WalletEncryptionArgs
+    public var signature: Data
+    public var data: Data?
+    public var hashToDirectlyVerify: Data?
+    public var forSelf: Bool
+    public init(
+        encryption: WalletEncryptionArgs,
+        signature: Data,
+        data: Data? = nil,
+        hashToDirectlyVerify: Data? = nil,
+        forSelf: Bool = false
+    ) {
+        self.encryption = encryption
+        self.signature = signature
+        self.data = data
+        self.hashToDirectlyVerify = hashToDirectlyVerify
+        self.forSelf = forSelf
+    }
+}
+
+public struct VerifySignatureResult: Sendable, Equatable {
+    public let valid: Bool
+    public init(valid: Bool) { self.valid = valid }
+}
+
+// MARK: - Linkage revelation types
+
+public struct RevealCounterpartyKeyLinkageArgs: Sendable {
+    public var counterparty: PublicKey
+    public var verifier: PublicKey
+    public var privileged: Bool
+    public var privilegedReason: String?
+    public init(counterparty: PublicKey, verifier: PublicKey, privileged: Bool = false, privilegedReason: String? = nil) {
+        self.counterparty = counterparty
+        self.verifier = verifier
+        self.privileged = privileged
+        self.privilegedReason = privilegedReason
+    }
+}
+
+public struct RevealSpecificKeyLinkageArgs: Sendable {
+    public var counterparty: WalletCounterparty
+    public var verifier: PublicKey
+    public var protocolID: WalletProtocol
+    public var keyID: String
+    public var privileged: Bool
+    public var privilegedReason: String?
+    public init(
+        counterparty: WalletCounterparty,
+        verifier: PublicKey,
+        protocolID: WalletProtocol,
+        keyID: String,
+        privileged: Bool = false,
+        privilegedReason: String? = nil
+    ) {
+        self.counterparty = counterparty
+        self.verifier = verifier
+        self.protocolID = protocolID
+        self.keyID = keyID
+        self.privileged = privileged
+        self.privilegedReason = privilegedReason
+    }
+}
+
+public struct RevealCounterpartyKeyLinkageResult: Sendable, Equatable {
+    public let prover: PublicKey
+    public let verifier: PublicKey
+    public let counterparty: PublicKey
+    public let revelationTime: String
+    public let encryptedLinkage: Data
+    public let encryptedLinkageProof: Data
+}
+
+public struct RevealSpecificKeyLinkageResult: Sendable, Equatable {
+    public let prover: PublicKey
+    public let verifier: PublicKey
+    public let counterparty: WalletCounterparty
+    public let protocolID: WalletProtocol
+    public let keyID: String
+    public let encryptedLinkage: Data
+    public let encryptedLinkageProof: Data
+    public let proofType: UInt8
+}

--- a/Sources/BSV/Wallet/substrates/HTTPWalletJSONSubstrate.swift
+++ b/Sources/BSV/Wallet/substrates/HTTPWalletJSONSubstrate.swift
@@ -1,0 +1,68 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// A `WalletSubstrate` that POSTs JSON to `<baseURL>/<method>` over HTTP.
+///
+/// Matches the wire format of the ts-sdk `HTTPWalletJSON` substrate. On a 2xx
+/// response whose body contains `{"status":"error",...}` it raises a
+/// `WalletError` that mirrors the remote wallet's error code and name.
+public struct HTTPWalletJSONSubstrate: WalletSubstrate {
+    public let baseURL: URL
+    public let session: URLSession
+
+    public init(baseURL: URL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func invoke(method: String, body: Data, originator: String?) async throws -> Data {
+        let url = baseURL.appendingPathComponent(method)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let originator {
+            // The remote wallet uses this to scope permissions to the caller.
+            request.setValue(originator, forHTTPHeaderField: "Originator")
+        }
+        request.httpBody = body
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw WalletError.transportFailure("non-HTTP response from \(url)")
+        }
+
+        // Try to detect an error envelope regardless of HTTP status code.
+        if let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let status = payload["status"] as? String, status == "error" {
+            let message = (payload["description"] as? String)
+                ?? (payload["message"] as? String)
+                ?? "remote wallet error"
+            let code = payload["code"] as? Int ?? 1
+            throw Self.walletError(for: code, message: message)
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            throw WalletError.transportFailure(
+                "HTTP \(http.statusCode) from \(url)"
+            )
+        }
+
+        return data
+    }
+
+    /// Map a ts-sdk `walletErrors` numeric code to a Swift `WalletError` case.
+    private static func walletError(for code: Int, message: String) -> WalletError {
+        switch code {
+        case 2: return .unsupportedAction(message)
+        case 3: return .invalidHmac
+        case 4: return .invalidSignature
+        case 5: return .reviewActions(message: message)
+        case 6: return .invalidParameter(name: "unknown", message: message)
+        case 7: return .insufficientFunds(totalSatoshisNeeded: 0, moreSatoshisNeeded: 0)
+        default: return .unknown(message)
+        }
+    }
+}

--- a/Sources/BSV/Wallet/substrates/WalletSubstrate.swift
+++ b/Sources/BSV/Wallet/substrates/WalletSubstrate.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// A transport that ferries BRC-100 JSON-shaped wallet calls to an external wallet.
+///
+/// Substrates are responsible for framing, transport, authentication with the
+/// wallet process, and translating any wire-level errors into `WalletError`.
+/// They receive JSON argument bodies and return JSON result bodies — semantic
+/// decoding is done by `WalletClient`.
+public protocol WalletSubstrate: Sendable {
+    /// Invoke a BRC-100 method by name, passing a JSON argument payload.
+    ///
+    /// - Parameters:
+    ///   - method: The BRC-100 method name (e.g. `"getPublicKey"`).
+    ///   - body: The encoded JSON argument payload.
+    ///   - originator: The FQDN of the calling application, if any.
+    /// - Returns: The raw JSON response body from the remote wallet.
+    /// - Throws: `WalletError` on transport, protocol, or decode failures.
+    func invoke(method: String, body: Data, originator: String?) async throws -> Data
+}

--- a/Tests/BSVTests/Auth/AuthNonceTests.swift
+++ b/Tests/BSVTests/Auth/AuthNonceTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import BSV
+
+final class AuthNonceTests: XCTestCase {
+
+    func testCreateVerifyRoundTrip() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let nonce = try await AuthNonce.create(wallet: wallet)
+        XCTAssertFalse(nonce.isEmpty)
+
+        let valid = try await AuthNonce.verify(nonce, wallet: wallet)
+        XCTAssertTrue(valid)
+    }
+
+    func testVerifyRejectsNonceFromAnotherWallet() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let attacker = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let nonce = try await AuthNonce.create(wallet: wallet)
+        let valid = try await AuthNonce.verify(nonce, wallet: attacker)
+        XCTAssertFalse(valid)
+    }
+
+    func testVerifyRejectsMalformedInput() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let invalid = try await AuthNonce.verify("not-base64!!", wallet: wallet)
+        XCTAssertFalse(invalid)
+    }
+
+    func testVerifyRejectsTamperedNonce() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let nonce = try await AuthNonce.create(wallet: wallet)
+
+        // Flip a byte in the decoded nonce and re-encode.
+        var raw = Data(base64Encoded: nonce)!
+        raw[0] ^= 0xFF
+        let tampered = raw.base64EncodedString()
+
+        let valid = try await AuthNonce.verify(tampered, wallet: wallet)
+        XCTAssertFalse(valid)
+    }
+}

--- a/Tests/BSVTests/Auth/CanonicalJSONTests.swift
+++ b/Tests/BSVTests/Auth/CanonicalJSONTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+@testable import BSV
+
+/// Cross-SDK conformance tests for `CanonicalJSON`.
+///
+/// The reference fixtures here are captured from a Node.js harness that
+/// reproduces ts-sdk's `JSON.stringify` behaviour over `VerifiableCertificate`
+/// and `RequestedCertificateSet`. ts-sdk signs the raw UTF-8 bytes of that
+/// stringification when building BRC-66 `certificateRequest` /
+/// `certificateResponse` pre-images, so any Swift implementation that wants
+/// cross-SDK verification to succeed must emit byte-for-byte identical
+/// output.
+///
+/// Key insertion order for certificates follows the ts-sdk constructor:
+/// `type`, `serialNumber`, `subject`, `certifier`, `revocationOutpoint`,
+/// `fields`, `signature`. Alphabetical ordering (which Swift's
+/// `JSONEncoder(.sortedKeys)` would produce) does NOT match.
+final class CanonicalJSONTests: XCTestCase {
+
+    // Pinned keys derived from fixed scalars. We can't use arbitrary
+    // 33-byte strings for the subject/certifier because `PublicKey(data:)`
+    // validates the point is on-curve, so instead we derive the two test
+    // keys from scalar 1 and scalar 2 and use their compressed encodings
+    // throughout the expected fixtures.
+    private var fixedSubject: PublicKey {
+        var scalar = Data(count: 32); scalar[31] = 0x01
+        return PublicKey.fromPrivateKey(PrivateKey(data: scalar)!)
+    }
+    private var fixedCertifier: PublicKey {
+        var scalar = Data(count: 32); scalar[31] = 0x02
+        return PublicKey.fromPrivateKey(PrivateKey(data: scalar)!)
+    }
+    private var fixedRevocation: String {
+        String(repeating: "0", count: 64) + ".0"
+    }
+    private var fixedType: Data { Data(base64Encoded: "dGVzdA==")! }
+    private var fixedSerial: Data { Data(base64Encoded: "c2VyaWFs")! }
+
+    /// Build the expected certificate object body (contents of the `{...}`
+    /// excluding braces) matching ts-sdk constructor insertion order.
+    private func expectedCertBody(
+        fieldsJSON: String,
+        signatureHex: String?
+    ) -> String {
+        let subjectHex = fixedSubject.hex
+        let certifierHex = fixedCertifier.hex
+        var body = #""type":"dGVzdA==","serialNumber":"c2VyaWFs""#
+        body += #","subject":"\#(subjectHex)""#
+        body += #","certifier":"\#(certifierHex)""#
+        body += #","revocationOutpoint":"\#(fixedRevocation)""#
+        body += #","fields":\#(fieldsJSON)"#
+        if let sig = signatureHex {
+            body += #","signature":"\#(sig)""#
+        }
+        return body
+    }
+
+    private func baseCert(
+        fields: [String: String],
+        signature: Data? = nil
+    ) -> Certificate {
+        Certificate(
+            type: fixedType,
+            serialNumber: fixedSerial,
+            subject: fixedSubject,
+            certifier: fixedCertifier,
+            revocationOutpoint: fixedRevocation,
+            fields: fields,
+            signature: signature
+        )
+    }
+
+    // MARK: - Certificate array
+
+    func testCanonicalCertificatesMatchesTSSDKFixtureWithSignature() {
+        let cert = baseCert(
+            fields: ["name": "Alice"],
+            signature: Data([0xDE, 0xAD, 0xBE, 0xEF])
+        )
+        let expected = "[{" + expectedCertBody(
+            fieldsJSON: #"{"name":"Alice"}"#,
+            signatureHex: "deadbeef"
+        ) + "}]"
+        let encoded = CanonicalJSON.encodeCertificates([cert])
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+
+    func testCanonicalCertificatesOmitsUndefinedSignature() {
+        let cert = baseCert(fields: ["name": "Alice"], signature: nil)
+        let expected = "[{" + expectedCertBody(
+            fieldsJSON: #"{"name":"Alice"}"#,
+            signatureHex: nil
+        ) + "}]"
+        let encoded = CanonicalJSON.encodeCertificates([cert])
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+
+    func testCanonicalCertificatesEscapesQuotesBackslashesAndNewlines() {
+        // JS JSON.stringify escapes " as \", \ as \\, and \n as \n.
+        let cert = baseCert(fields: ["name": "He said \"hi\"\nand \\ left"])
+        let expected = "[{" + expectedCertBody(
+            fieldsJSON: #"{"name":"He said \"hi\"\nand \\ left"}"#,
+            signatureHex: nil
+        ) + "}]"
+        let encoded = CanonicalJSON.encodeCertificates([cert])
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+
+    func testCanonicalCertificatesEmitsUnicodeAsUTF8Literal() {
+        // JS JSON.stringify leaves non-ASCII scalars alone (they are emitted
+        // as raw UTF-8 in the output bytes) unless explicitly asked to
+        // ASCII-escape them.
+        let cert = baseCert(fields: ["greeting": "héllo 日本"])
+        let expected = "[{" + expectedCertBody(
+            fieldsJSON: #"{"greeting":"héllo 日本"}"#,
+            signatureHex: nil
+        ) + "}]"
+        let encoded = CanonicalJSON.encodeCertificates([cert])
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+
+    func testCanonicalCertificatesEmptyFields() {
+        let cert = baseCert(fields: [:])
+        let expected = "[{" + expectedCertBody(
+            fieldsJSON: "{}",
+            signatureHex: nil
+        ) + "}]"
+        let encoded = CanonicalJSON.encodeCertificates([cert])
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+
+    func testCanonicalCertificatesEmptyArray() {
+        let encoded = CanonicalJSON.encodeCertificates([])
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), "[]")
+    }
+
+    func testCanonicalCertificatesKeyOrderIsNotAlphabetical() {
+        // This is the regression guard for H3: the previous implementation
+        // used JSONEncoder(.sortedKeys), which emits alphabetical key
+        // order. That does NOT match ts-sdk. Assert the emitted bytes
+        // have `type` BEFORE `certifier` (insertion order) so the test
+        // fails if anyone reintroduces a sorted encoder.
+        let cert = baseCert(fields: ["name": "Alice"])
+        let encoded = CanonicalJSON.encodeCertificates([cert])
+        let s = String(data: encoded, encoding: .utf8) ?? ""
+        let typeIdx = s.range(of: "\"type\"")?.lowerBound
+        let certIdx = s.range(of: "\"certifier\"")?.lowerBound
+        XCTAssertNotNil(typeIdx)
+        XCTAssertNotNil(certIdx)
+        if let t = typeIdx, let c = certIdx {
+            XCTAssertTrue(t < c, "type must be serialised before certifier (ts-sdk insertion order)")
+        }
+    }
+
+    // MARK: - RequestedCertificateSet
+
+    func testCanonicalRequestedCertificateSetSingleType() throws {
+        let rcs = RequestedCertificateSet(
+            certifiers: ["aaaa", "bbbb"],
+            types: ["dHlwZQ==": ["name", "email"]]
+        )
+        let expected = #"{"certifiers":["aaaa","bbbb"],"types":{"dHlwZQ==":["name","email"]}}"#
+        let encoded = try CanonicalJSON.encodeRequestedCertificateSet(rcs)
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+
+    func testCanonicalRequestedCertificateSetEmpty() throws {
+        let rcs = RequestedCertificateSet()
+        let expected = #"{"certifiers":[],"types":{}}"#
+        let encoded = try CanonicalJSON.encodeRequestedCertificateSet(rcs)
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+
+    func testCanonicalRequestedCertificateSetNoFieldNames() throws {
+        let rcs = RequestedCertificateSet(
+            certifiers: ["aabb"],
+            types: ["dHlwZQ==": []]
+        )
+        let expected = #"{"certifiers":["aabb"],"types":{"dHlwZQ==":[]}}"#
+        let encoded = try CanonicalJSON.encodeRequestedCertificateSet(rcs)
+        XCTAssertEqual(String(data: encoded, encoding: .utf8), expected)
+    }
+}

--- a/Tests/BSVTests/Auth/CertificateTests.swift
+++ b/Tests/BSVTests/Auth/CertificateTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import BSV
+
+final class CertificateTests: XCTestCase {
+
+    private func randomBytes(_ count: Int) -> Data {
+        var data = Data(count: count)
+        _ = data.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, count, $0.baseAddress!)
+        }
+        return data
+    }
+
+    private func sampleCertificate(subject: PublicKey, certifier: PublicKey) -> Certificate {
+        Certificate(
+            type: randomBytes(32),
+            serialNumber: randomBytes(32),
+            subject: subject,
+            certifier: certifier,
+            revocationOutpoint: String(repeating: "a", count: 64) + ".0",
+            fields: ["name": "Alice", "email": "alice@example.com"],
+            signature: nil
+        )
+    }
+
+    // MARK: - Binary round-trip
+
+    func testBinaryRoundTrip() throws {
+        let subjectKey = PrivateKey.random()!
+        let certifierKey = PrivateKey.random()!
+        let cert = sampleCertificate(
+            subject: PublicKey.fromPrivateKey(subjectKey),
+            certifier: PublicKey.fromPrivateKey(certifierKey)
+        )
+
+        let bytes = cert.toBinary(includeSignature: false)
+        let parsed = try XCTUnwrap(Certificate.fromBinary(bytes))
+        XCTAssertEqual(parsed.type, cert.type)
+        XCTAssertEqual(parsed.serialNumber, cert.serialNumber)
+        XCTAssertEqual(parsed.subject, cert.subject)
+        XCTAssertEqual(parsed.certifier, cert.certifier)
+        XCTAssertEqual(parsed.revocationOutpoint, cert.revocationOutpoint)
+        XCTAssertEqual(parsed.fields, cert.fields)
+        XCTAssertNil(parsed.signature)
+    }
+
+    // MARK: - Sign / verify round-trip
+
+    func testSignVerifyRoundTrip() async throws {
+        let certifierWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let certifierIdentity = try await certifierWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        var cert = sampleCertificate(
+            subject: PublicKey.fromPrivateKey(PrivateKey.random()!),
+            certifier: certifierIdentity
+        )
+        try await cert.sign(certifierWallet: certifierWallet)
+        XCTAssertNotNil(cert.signature)
+        XCTAssertFalse(cert.signature!.isEmpty)
+
+        let ok = try await cert.verify()
+        XCTAssertTrue(ok)
+    }
+
+    func testTamperedFieldsFailVerification() async throws {
+        let certifierWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        var cert = sampleCertificate(
+            subject: PublicKey.fromPrivateKey(PrivateKey.random()!),
+            certifier: PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+        try await cert.sign(certifierWallet: certifierWallet)
+
+        // Mutate a field after signing.
+        cert.fields["name"] = "Mallory"
+        let ok = try await cert.verify()
+        XCTAssertFalse(ok)
+    }
+
+    func testDoubleSignIsRejected() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        var cert = sampleCertificate(
+            subject: PublicKey.fromPrivateKey(PrivateKey.random()!),
+            certifier: PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+        try await cert.sign(certifierWallet: wallet)
+
+        do {
+            try await cert.sign(certifierWallet: wallet)
+            XCTFail("expected certificateInvalid error")
+        } catch AuthError.certificateInvalid {
+            // expected
+        }
+    }
+
+    // MARK: - Master / verifiable certificates
+
+    func testMasterCertificateIssueAndVerifierKeyring() async throws {
+        let certifierWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let subjectWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let verifierWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let subjectIdentity = try await subjectWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+        let verifierIdentity = try await verifierWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+        let certifierIdentity = try await certifierWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        let master = try await MasterCertificate.issueCertificateForSubject(
+            certifierWallet: certifierWallet,
+            subject: subjectIdentity,
+            fields: ["name": "Bob", "dob": "2000-01-01"],
+            certificateType: randomBytes(32)
+        )
+
+        // Subject re-encrypts the keyring for the verifier.
+        let verifierKeyring = try await MasterCertificate.createKeyringForVerifier(
+            subjectWallet: subjectWallet,
+            certifier: .publicKey(certifierIdentity),
+            verifier: .publicKey(verifierIdentity),
+            fields: master.certificate.fields,
+            fieldsToReveal: ["name"],
+            masterKeyring: master.masterKeyring,
+            serialNumber: master.certificate.serialNumber
+        )
+
+        var verifiable = VerifiableCertificate(
+            certificate: master.certificate,
+            keyring: verifierKeyring
+        )
+        let decrypted = try await verifiable.decryptFields(verifierWallet: verifierWallet)
+        XCTAssertEqual(decrypted["name"], "Bob")
+        XCTAssertNil(decrypted["dob"]) // not revealed
+    }
+}

--- a/Tests/BSVTests/Auth/PeerTests.swift
+++ b/Tests/BSVTests/Auth/PeerTests.swift
@@ -534,7 +534,7 @@ private struct CertResponseFixture {
         // Mint a nonce for Bob-side and sign the JSON payload the way
         // processCertificateResponse expects.
         let bobNonce = try await AuthNonce.create(wallet: bobWallet)
-        let jsonData = try Peer.canonicalCertJSON(certs)
+        let jsonData = CanonicalJSON.encodeCertificates(certs)
 
         let aliceIdentity = try await aliceWallet.getPublicKey(
             args: GetPublicKeyArgs(identityKey: true)

--- a/Tests/BSVTests/Auth/PeerTests.swift
+++ b/Tests/BSVTests/Auth/PeerTests.swift
@@ -215,6 +215,48 @@ final class PeerTests: XCTestCase {
         withExtendedLifetime(fixture.bob) {}
     }
 
+    // MARK: - Vuln 2: Unsigned initialRequest session injection
+
+    /// An attacker-controlled peer sends Alice an unsigned BRC-66
+    /// `initialRequest` claiming identity `victim`. Alice's responder
+    /// path creates a session whose `peerIdentityKey` is the claimed key
+    /// — but that claim is UNVERIFIED. A subsequent
+    /// `getAuthenticatedSession(identityKey: victim)` call must NOT
+    /// return the attacker-seeded session.
+    func testInitialRequestDoesNotEnableIdentityLookup() async throws {
+        let (aliceTransport, attackerTransport) = await makeConnectedTransports()
+
+        let aliceWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let alice = try await Peer(wallet: aliceWallet, transport: aliceTransport)
+
+        // Pick a victim identity entirely unrelated to either party.
+        let victimKey = PrivateKey.random()!
+        let victimIdentity = PublicKey.fromPrivateKey(victimKey)
+
+        // Attacker has their own wallet but crafts a raw initialRequest
+        // AuthMessage whose identityKey is the victim's public key.
+        let attackerWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let attackerInitialNonce = try await AuthNonce.create(wallet: attackerWallet)
+
+        let spoofed = AuthMessage(
+            messageType: .initialRequest,
+            identityKey: victimIdentity,
+            initialNonce: attackerInitialNonce
+        )
+        try await attackerTransport.send(spoofed)
+
+        // Drain in-flight actor work so Alice's processInitialRequest has
+        // completed.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Identity lookup must not return the attacker-seeded session.
+        let byIdentity = await alice.sessionManager.getSession(victimIdentity.hex)
+        XCTAssertNil(
+            byIdentity,
+            "attacker-seeded session must not be reachable via identity-key lookup"
+        )
+    }
+
 }
 
 // MARK: - Certificate-response test fixture

--- a/Tests/BSVTests/Auth/PeerTests.swift
+++ b/Tests/BSVTests/Auth/PeerTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import BSV
+
+/// A pair of in-memory transports connected back-to-back.
+///
+/// Each side can `send` a message; the other side's `onData` callback is
+/// invoked asynchronously. The pair is thread-safe by virtue of each side
+/// being its own actor.
+actor InMemoryTransport: Transport {
+    private var partner: InMemoryTransport?
+    private var onDataCallback: (@Sendable (AuthMessage) async throws -> Void)?
+
+    func connect(to partner: InMemoryTransport) {
+        self.partner = partner
+    }
+
+    func send(_ message: AuthMessage) async throws {
+        guard let partner else {
+            throw AuthError.transportFailure("in-memory transport is not connected")
+        }
+        await partner.deliver(message)
+    }
+
+    func onData(_ callback: @escaping @Sendable (AuthMessage) async throws -> Void) async throws {
+        self.onDataCallback = callback
+    }
+
+    fileprivate func deliver(_ message: AuthMessage) async {
+        guard let cb = onDataCallback else { return }
+        do {
+            try await cb(message)
+        } catch {
+            // Tests make errors observable via XCTFail in their own handlers.
+        }
+    }
+}
+
+/// Create a pair of connected transports.
+func makeConnectedTransports() async -> (InMemoryTransport, InMemoryTransport) {
+    let a = InMemoryTransport()
+    let b = InMemoryTransport()
+    await a.connect(to: b)
+    await b.connect(to: a)
+    return (a, b)
+}
+
+final class PeerTests: XCTestCase {
+
+    func testHandshakeEstablishesAuthenticatedSession() async throws {
+        let (transportA, transportB) = await makeConnectedTransports()
+
+        let aliceWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let bobWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let alice = try await Peer(wallet: aliceWallet, transport: transportA)
+        let bob = try await Peer(wallet: bobWallet, transport: transportB)
+        _ = bob // Keep Bob alive — the onData callback captures self weakly.
+
+        let bobIdentity = try await bobWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        let session = try await alice.getAuthenticatedSession(identityKey: bobIdentity)
+        XCTAssertTrue(session.isAuthenticated)
+        XCTAssertEqual(session.peerIdentityKey, bobIdentity)
+        withExtendedLifetime(bob) {}
+    }
+
+    func testGeneralMessageRoundTrip() async throws {
+        let (transportA, transportB) = await makeConnectedTransports()
+
+        let aliceWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let bobWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let alice = try await Peer(wallet: aliceWallet, transport: transportA)
+        let bob = try await Peer(wallet: bobWallet, transport: transportB)
+
+        // Collect messages Bob receives.
+        let received = MessageCollector()
+        await bob.listenForGeneralMessages { identity, payload in
+            Task { await received.append(identity: identity, payload: payload) }
+        }
+
+        let bobIdentity = try await bobWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+        let payload = Data("hello peer".utf8)
+        try await alice.toPeer(payload, identityKey: bobIdentity)
+
+        // Give Bob's handler a moment to run.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let received0 = await received.all()
+        XCTAssertEqual(received0.count, 1)
+        XCTAssertEqual(received0.first?.payload, payload)
+        withExtendedLifetime(bob) {}
+    }
+
+}
+
+// MARK: - Helpers
+
+private actor MessageCollector {
+    struct Entry: Sendable {
+        let identity: PublicKey
+        let payload: Data
+    }
+    private var entries: [Entry] = []
+
+    func append(identity: PublicKey, payload: Data) {
+        entries.append(Entry(identity: identity, payload: payload))
+    }
+
+    func all() -> [Entry] { entries }
+}

--- a/Tests/BSVTests/Auth/PeerTests.swift
+++ b/Tests/BSVTests/Auth/PeerTests.swift
@@ -293,6 +293,81 @@ final class PeerTests: XCTestCase {
         withExtendedLifetime(bob) {}
     }
 
+    // MARK: - H1: Handshake continuation leak on malformed initialResponse
+
+    /// A malformed `initialResponse` (e.g. invalid signature) must cause
+    /// `initiateHandshake` to throw rather than hang forever. The waiter
+    /// continuation must be resumed on any failure path inside
+    /// `processInitialResponse`, not only on success.
+    func testMalformedInitialResponseThrowsRatherThanHangs() async throws {
+        let (aliceTransport, peerTransport) = await makeConnectedTransports()
+
+        let aliceWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let attackerWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let alice = try await Peer(wallet: aliceWallet, transport: aliceTransport)
+
+        let attackerIdentity = try await attackerWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        // Hook the peer transport so any incoming initialRequest is
+        // answered with a malformed initialResponse: echo Alice's nonce
+        // but sign with a garbage payload so signature verification
+        // fails. processInitialResponse must fail and wake the waiter.
+        try await peerTransport.onData { [peerTransport, attackerWallet, attackerIdentity] message in
+            guard message.messageType == .initialRequest,
+                  let aliceNonce = message.initialNonce else { return }
+
+            let attackerNonce = try await AuthNonce.create(wallet: attackerWallet)
+            // Deliberately sign unrelated data — verification will fail
+            // inside processInitialResponse, which must surface as an
+            // error from getAuthenticatedSession rather than a deadlock.
+            let badSig = try await attackerWallet.createSignature(args: CreateSignatureArgs(
+                encryption: WalletEncryptionArgs(
+                    protocolID: Peer.signatureProtocol,
+                    keyID: "\(aliceNonce) \(attackerNonce)",
+                    counterparty: .publicKey(message.identityKey)
+                ),
+                data: Data("garbage".utf8)
+            )).signature
+
+            let response = AuthMessage(
+                messageType: .initialResponse,
+                identityKey: attackerIdentity,
+                initialNonce: attackerNonce,
+                yourNonce: aliceNonce,
+                signature: badSig
+            )
+            try await peerTransport.send(response)
+        }
+
+        // Race the handshake against a watchdog. If the fix is missing,
+        // getAuthenticatedSession hangs forever and the watchdog wins,
+        // causing the test to fail rather than hanging the suite.
+        enum Outcome: Sendable { case threw, succeeded, timedOut }
+        let outcome: Outcome = await withTaskGroup(of: Outcome.self) { group in
+            group.addTask {
+                do {
+                    _ = try await alice.getAuthenticatedSession(identityKey: attackerIdentity)
+                    return .succeeded
+                } catch {
+                    return .threw
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                return .timedOut
+            }
+            let first = await group.next() ?? .timedOut
+            group.cancelAll()
+            return first
+        }
+        XCTAssertEqual(
+            outcome, .threw,
+            "malformed initialResponse must cause initiateHandshake to throw, not hang or succeed"
+        )
+    }
+
     // MARK: - Vuln 2: Unsigned initialRequest session injection
 
     /// An attacker-controlled peer sends Alice an unsigned BRC-66

--- a/Tests/BSVTests/Auth/PeerTests.swift
+++ b/Tests/BSVTests/Auth/PeerTests.swift
@@ -215,6 +215,84 @@ final class PeerTests: XCTestCase {
         withExtendedLifetime(fixture.bob) {}
     }
 
+    // MARK: - Vuln 3: General message identity spoofing
+
+    /// A general message whose `identityKey` does not match the session's
+    /// stored `peerIdentityKey` must be rejected, even if the inner
+    /// signature is cryptographically valid against the claimed key.
+    /// BRC-43 verification is ECDH-symmetric, so without this check any
+    /// third party could forge messages into an existing session by
+    /// signing with their own root key.
+    func testGeneralMessageRejectsMismatchedIdentity() async throws {
+        let (aliceTransport, bobTransport) = await makeConnectedTransports()
+
+        let aliceWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let bobWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let charlieWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let alice = try await Peer(wallet: aliceWallet, transport: aliceTransport)
+        let bob = try await Peer(wallet: bobWallet, transport: bobTransport)
+
+        let bobIdentity = try await bobWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+        let aliceIdentity = try await aliceWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+        let charlieIdentity = try await charlieWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        // Establish a legitimate Alice-Bob session via the standard
+        // handshake. Alice's session now has peerIdentityKey = Bob.
+        _ = try await alice.getAuthenticatedSession(identityKey: bobIdentity)
+
+        // Collect whatever Alice's general-message listener delivers so we
+        // can assert the forged message never makes it through.
+        let received = MessageCollector()
+        await alice.listenForGeneralMessages { identity, payload in
+            Task { await received.append(identity: identity, payload: payload) }
+        }
+
+        // Charlie crafts a general message claiming identityKey = Charlie,
+        // targeted at Alice's session nonce. He signs with his own root
+        // key under counterparty = Alice — a signature that would pass
+        // verification if Alice naively verified with
+        // counterparty = message.identityKey.
+        let aliceSessionLookup = await alice.sessionManager.getSession(bobIdentity.hex)
+        let aliceSession = try XCTUnwrap(aliceSessionLookup)
+        let charlieNonce = try await AuthNonce.create(wallet: charlieWallet)
+        let payload = Data("spoofed".utf8)
+        let charlieSig = try await charlieWallet.createSignature(args: CreateSignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Peer.signatureProtocol,
+                keyID: "\(charlieNonce) \(aliceSession.sessionNonce)",
+                counterparty: .publicKey(aliceIdentity)
+            ),
+            data: payload
+        )).signature
+
+        let spoofed = AuthMessage(
+            messageType: .general,
+            identityKey: charlieIdentity,
+            nonce: charlieNonce,
+            yourNonce: aliceSession.sessionNonce,
+            payload: payload,
+            signature: charlieSig
+        )
+
+        // Deliver via Bob's transport so Alice's onData processes it.
+        try await bobTransport.send(spoofed)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let delivered = await received.all()
+        XCTAssertEqual(
+            delivered.count, 0,
+            "spoofed general message with mismatched identity must not be delivered"
+        )
+        withExtendedLifetime(bob) {}
+    }
+
     // MARK: - Vuln 2: Unsigned initialRequest session injection
 
     /// An attacker-controlled peer sends Alice an unsigned BRC-66

--- a/Tests/BSVTests/Auth/PeerTests.swift
+++ b/Tests/BSVTests/Auth/PeerTests.swift
@@ -96,6 +96,287 @@ final class PeerTests: XCTestCase {
         withExtendedLifetime(bob) {}
     }
 
+    // MARK: - Vuln 1: Certificate verification bypass
+
+    /// A legitimate certificate — properly signed by a certifier that Alice
+    /// trusts, with the correct subject and type — is accepted, and the
+    /// session flag flips to `certificatesValidated = true`.
+    func testCertificateResponseAcceptsValidCertificate() async throws {
+        let fixture = try await CertResponseFixture.make(requireCerts: true)
+        let cert = try await fixture.buildCertificate(
+            subject: fixture.bobIdentity,
+            certifierWallet: fixture.certifierWallet,
+            type: fixture.requestedType
+        )
+        // Sanity check: the cert we built must pass cert.verify() on its own.
+        let directVerify = try await cert.verify()
+        XCTAssertTrue(directVerify, "fixture produced an unverifiable cert")
+
+        try await fixture.sendCertificateResponse([cert])
+        let validated = await fixture.waitForCertificatesValidated()
+        XCTAssertTrue(validated, "valid certificate should flip certificatesValidated")
+        withExtendedLifetime(fixture.bob) {}
+    }
+
+    /// A certificate with no signature must be rejected.
+    func testCertificateResponseRejectsUnsignedCertificate() async throws {
+        let fixture = try await CertResponseFixture.make(requireCerts: true)
+        var cert = try await fixture.buildCertificate(
+            subject: fixture.bobIdentity,
+            certifierWallet: fixture.certifierWallet,
+            type: fixture.requestedType
+        )
+        cert.signature = nil
+
+        try await fixture.sendCertificateResponse([cert])
+
+        let sessionLookup = await fixture.alice.sessionManager.getSession(fixture.bobIdentity.hex)
+        let session = try XCTUnwrap(sessionLookup)
+        XCTAssertFalse(session.certificatesValidated)
+        withExtendedLifetime(fixture.bob) {}
+    }
+
+    /// A certificate signed by a certifier NOT in `certificatesToRequest.certifiers`
+    /// must be rejected.
+    func testCertificateResponseRejectsWrongCertifier() async throws {
+        let fixture = try await CertResponseFixture.make(requireCerts: true)
+        let otherCertifier = ProtoWallet(rootKey: PrivateKey.random()!)
+        let cert = try await fixture.buildCertificate(
+            subject: fixture.bobIdentity,
+            certifierWallet: otherCertifier,
+            type: fixture.requestedType
+        )
+
+        try await fixture.sendCertificateResponse([cert])
+
+        let sessionLookup = await fixture.alice.sessionManager.getSession(fixture.bobIdentity.hex)
+        let session = try XCTUnwrap(sessionLookup)
+        XCTAssertFalse(session.certificatesValidated)
+        withExtendedLifetime(fixture.bob) {}
+    }
+
+    /// A certificate with a type NOT in `certificatesToRequest.types` must
+    /// be rejected.
+    func testCertificateResponseRejectsWrongType() async throws {
+        let fixture = try await CertResponseFixture.make(requireCerts: true)
+        var other = Data(count: 32)
+        _ = other.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
+        }
+        let cert = try await fixture.buildCertificate(
+            subject: fixture.bobIdentity,
+            certifierWallet: fixture.certifierWallet,
+            type: other
+        )
+
+        try await fixture.sendCertificateResponse([cert])
+
+        let sessionLookup = await fixture.alice.sessionManager.getSession(fixture.bobIdentity.hex)
+        let session = try XCTUnwrap(sessionLookup)
+        XCTAssertFalse(session.certificatesValidated)
+        withExtendedLifetime(fixture.bob) {}
+    }
+
+    /// A certificate whose subject does not match the claimed message identity
+    /// must be rejected.
+    func testCertificateResponseRejectsWrongSubject() async throws {
+        let fixture = try await CertResponseFixture.make(requireCerts: true)
+        let strangerSubject = PublicKey.fromPrivateKey(PrivateKey.random()!)
+        let cert = try await fixture.buildCertificate(
+            subject: strangerSubject,
+            certifierWallet: fixture.certifierWallet,
+            type: fixture.requestedType
+        )
+
+        try await fixture.sendCertificateResponse([cert])
+
+        let sessionLookup = await fixture.alice.sessionManager.getSession(fixture.bobIdentity.hex)
+        let session = try XCTUnwrap(sessionLookup)
+        XCTAssertFalse(session.certificatesValidated)
+        withExtendedLifetime(fixture.bob) {}
+    }
+
+    /// A certificate whose signature is complete garbage must be rejected.
+    func testCertificateResponseRejectsForgedSignature() async throws {
+        let fixture = try await CertResponseFixture.make(requireCerts: true)
+        var cert = try await fixture.buildCertificate(
+            subject: fixture.bobIdentity,
+            certifierWallet: fixture.certifierWallet,
+            type: fixture.requestedType
+        )
+        // Replace the signature with random bytes of a plausible DER length.
+        cert.signature = Data(repeating: 0x30, count: 70)
+
+        try await fixture.sendCertificateResponse([cert])
+
+        let sessionLookup = await fixture.alice.sessionManager.getSession(fixture.bobIdentity.hex)
+        let session = try XCTUnwrap(sessionLookup)
+        XCTAssertFalse(session.certificatesValidated)
+        withExtendedLifetime(fixture.bob) {}
+    }
+
+}
+
+// MARK: - Certificate-response test fixture
+
+/// Scaffolding for tests that exercise `processCertificateResponse` without
+/// running a full BRC-66 certificate-response flow. Stands up two real peers
+/// (Alice + Bob) with Alice configured to require certificates from a known
+/// certifier, then exposes a helper to send a hand-signed `certificateResponse`
+/// message from Bob to Alice using the wire protocol.
+private struct CertResponseFixture {
+    let alice: Peer
+    let bob: Peer
+    let aliceWallet: ProtoWallet
+    let bobWallet: ProtoWallet
+    let certifierWallet: ProtoWallet
+    let bobIdentity: PublicKey
+    let certifierIdentity: PublicKey
+    let requestedType: Data
+    let transportB: InMemoryTransport
+
+    /// Build a fixture with an in-memory transport pair, run the BRC-66
+    /// handshake so Alice has an authenticated session with Bob, and return
+    /// the ready-to-use handles.
+    static func make(requireCerts: Bool) async throws -> CertResponseFixture {
+        let (transportA, transportB) = await makeConnectedTransports()
+
+        let aliceWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let bobWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let certifierWallet = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let certifierIdentity = try await certifierWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        // Pin the certificate type so the test can build a matching cert.
+        var typeBytes = Data(count: 32)
+        _ = typeBytes.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
+        }
+
+        let requested: RequestedCertificateSet
+        if requireCerts {
+            requested = RequestedCertificateSet(
+                certifiers: [certifierIdentity.hex],
+                types: [typeBytes.base64EncodedString(): ["name"]]
+            )
+        } else {
+            requested = RequestedCertificateSet()
+        }
+
+        let alice = try await Peer(
+            wallet: aliceWallet,
+            transport: transportA,
+            certificatesToRequest: requested
+        )
+        let bob = try await Peer(wallet: bobWallet, transport: transportB)
+
+        let bobIdentity = try await bobWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        // Run the BRC-66 handshake to completion. Alice's
+        // `getAuthenticatedSession` does not block on certificate
+        // validation (only `toPeer` does), so it returns once the
+        // handshake itself is authenticated. At that point Alice's session
+        // has `certificatesValidated = false` which is exactly the
+        // pre-condition the tests want before exercising
+        // processCertificateResponse.
+        _ = try await alice.getAuthenticatedSession(identityKey: bobIdentity)
+
+        return CertResponseFixture(
+            alice: alice,
+            bob: bob,
+            aliceWallet: aliceWallet,
+            bobWallet: bobWallet,
+            certifierWallet: certifierWallet,
+            bobIdentity: bobIdentity,
+            certifierIdentity: certifierIdentity,
+            requestedType: typeBytes,
+            transportB: transportB
+        )
+    }
+
+    /// Build a signed BRC-103 certificate with a pinned type.
+    func buildCertificate(
+        subject: PublicKey,
+        certifierWallet: WalletInterface,
+        type: Data
+    ) async throws -> Certificate {
+        var serial = Data(count: 32)
+        _ = serial.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
+        }
+        let certifierID = try await certifierWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+        var cert = Certificate(
+            type: type,
+            serialNumber: serial,
+            subject: subject,
+            certifier: certifierID,
+            revocationOutpoint: String(repeating: "0", count: 64) + ".0",
+            fields: ["name": "Bob"],
+            signature: nil
+        )
+        try await cert.sign(certifierWallet: certifierWallet)
+        return cert
+    }
+
+    /// Construct a properly-signed outer `certificateResponse` envelope and
+    /// deliver it to Alice via Bob's transport. The outer signature is
+    /// correct — what the tests exercise is the inner certificate
+    /// verification.
+    func sendCertificateResponse(_ certs: [Certificate]) async throws {
+        // Fetch Alice's view of the session so we can address the response
+        // with the nonce Alice minted.
+        guard let session = await alice.sessionManager.getSession(bobIdentity.hex) else {
+            throw AuthError.sessionNotFound("alice has no session for bob")
+        }
+        let aliceSessionNonce = session.sessionNonce
+
+        // Mint a nonce for Bob-side and sign the JSON payload the way
+        // processCertificateResponse expects.
+        let bobNonce = try await AuthNonce.create(wallet: bobWallet)
+        let jsonData = try Peer.canonicalCertJSON(certs)
+
+        let aliceIdentity = try await aliceWallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+
+        let signature = try await bobWallet.createSignature(args: CreateSignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: Peer.signatureProtocol,
+                keyID: "\(bobNonce) \(aliceSessionNonce)",
+                counterparty: .publicKey(aliceIdentity)
+            ),
+            data: jsonData
+        )).signature
+
+        let response = AuthMessage(
+            messageType: .certificateResponse,
+            identityKey: bobIdentity,
+            nonce: bobNonce,
+            yourNonce: aliceSessionNonce,
+            certificates: certs,
+            signature: signature
+        )
+
+        try await transportB.send(response)
+    }
+
+    /// Spin-wait on Alice's session until `certificatesValidated` flips
+    /// to true, or a bounded timeout elapses. Returns the final value.
+    func waitForCertificatesValidated() async -> Bool {
+        for _ in 0..<50 {
+            let s = await alice.sessionManager.getSession(bobIdentity.hex)
+            if s?.certificatesValidated == true { return true }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        let final = await alice.sessionManager.getSession(bobIdentity.hex)
+        return final?.certificatesValidated ?? false
+    }
 }
 
 // MARK: - Helpers

--- a/Tests/BSVTests/Auth/SessionManagerTests.swift
+++ b/Tests/BSVTests/Auth/SessionManagerTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import BSV
+
+final class SessionManagerTests: XCTestCase {
+
+    private func makeSession(
+        sessionNonce: String,
+        identity: PrivateKey? = nil,
+        authenticated: Bool = true,
+        lastUpdate: Date = Date()
+    ) -> PeerSession {
+        let peerIdentity = identity.map { PublicKey.fromPrivateKey($0) }
+        return PeerSession(
+            isAuthenticated: authenticated,
+            sessionNonce: sessionNonce,
+            peerIdentityKey: peerIdentity,
+            lastUpdate: lastUpdate
+        )
+    }
+
+    func testLookupBySessionNonce() {
+        let manager = SessionManager()
+        let session = makeSession(sessionNonce: "nonce-1")
+        manager.addSession(session)
+
+        let fetched = manager.getSession("nonce-1")
+        XCTAssertNotNil(fetched)
+        XCTAssertEqual(fetched?.sessionNonce, "nonce-1")
+    }
+
+    func testLookupByIdentityKey() {
+        let manager = SessionManager()
+        let identity = PrivateKey.random()!
+        let session = makeSession(sessionNonce: "s1", identity: identity)
+        manager.addSession(session)
+
+        let fetchedByHex = manager.getSession(PublicKey.fromPrivateKey(identity).hex)
+        XCTAssertEqual(fetchedByHex?.sessionNonce, "s1")
+    }
+
+    func testMostRecentSessionWinsForDuplicateIdentity() {
+        let manager = SessionManager()
+        let identity = PrivateKey.random()!
+        let older = Date(timeIntervalSince1970: 1000)
+        let newer = Date(timeIntervalSince1970: 2000)
+
+        manager.addSession(makeSession(sessionNonce: "old", identity: identity, lastUpdate: older))
+        manager.addSession(makeSession(sessionNonce: "new", identity: identity, lastUpdate: newer))
+
+        let fetched = manager.getSession(PublicKey.fromPrivateKey(identity).hex)
+        XCTAssertEqual(fetched?.sessionNonce, "new")
+    }
+
+    func testRemoveSession() {
+        let manager = SessionManager()
+        let identity = PrivateKey.random()!
+        let session = makeSession(sessionNonce: "remove-me", identity: identity)
+        manager.addSession(session)
+
+        XCTAssertTrue(manager.hasSession("remove-me"))
+        manager.removeSession(session)
+        XCTAssertFalse(manager.hasSession("remove-me"))
+        XCTAssertNil(manager.getSession(PublicKey.fromPrivateKey(identity).hex))
+    }
+
+    func testUpdateSessionReplacesIdentityIndexWhenChanged() {
+        let manager = SessionManager()
+        let originalIdentity = PrivateKey.random()!
+        let newIdentity = PrivateKey.random()!
+
+        var session = makeSession(sessionNonce: "mut", identity: originalIdentity)
+        manager.addSession(session)
+
+        session.peerIdentityKey = PublicKey.fromPrivateKey(newIdentity)
+        manager.updateSession(session)
+
+        XCTAssertNil(manager.getSession(PublicKey.fromPrivateKey(originalIdentity).hex))
+        XCTAssertEqual(
+            manager.getSession(PublicKey.fromPrivateKey(newIdentity).hex)?.sessionNonce,
+            "mut"
+        )
+    }
+}

--- a/Tests/BSVTests/Auth/SessionManagerTests.swift
+++ b/Tests/BSVTests/Auth/SessionManagerTests.swift
@@ -7,6 +7,7 @@ final class SessionManagerTests: XCTestCase {
         sessionNonce: String,
         identity: PrivateKey? = nil,
         authenticated: Bool = true,
+        peerIdentityKeyVerified: Bool = true,
         lastUpdate: Date = Date()
     ) -> PeerSession {
         let peerIdentity = identity.map { PublicKey.fromPrivateKey($0) }
@@ -14,6 +15,7 @@ final class SessionManagerTests: XCTestCase {
             isAuthenticated: authenticated,
             sessionNonce: sessionNonce,
             peerIdentityKey: peerIdentity,
+            peerIdentityKeyVerified: peerIdentityKeyVerified,
             lastUpdate: lastUpdate
         )
     }
@@ -79,5 +81,61 @@ final class SessionManagerTests: XCTestCase {
             manager.getSession(PublicKey.fromPrivateKey(newIdentity).hex)?.sessionNonce,
             "mut"
         )
+    }
+
+    // MARK: - Vuln 2: identity-key indexing requires verification
+
+    /// A session with `peerIdentityKeyVerified = false` (e.g. created from
+    /// an unsigned BRC-66 `initialRequest`) must be reachable by nonce but
+    /// NOT by identity-key lookup. Otherwise an attacker could seed a
+    /// session claiming any identity key and have a later
+    /// `getSession(<victim identity hex>)` call return it.
+    func testUnverifiedSessionIsNotIndexedByIdentity() {
+        let manager = SessionManager()
+        let victim = PrivateKey.random()!
+        let session = makeSession(
+            sessionNonce: "attacker-seeded",
+            identity: victim,
+            peerIdentityKeyVerified: false
+        )
+        manager.addSession(session)
+
+        // Nonce lookup still works — it's how the BRC-66 handshake
+        // continues processing messages in this session.
+        XCTAssertNotNil(manager.getSession("attacker-seeded"))
+
+        // Identity lookup must not find it.
+        XCTAssertNil(manager.getSession(PublicKey.fromPrivateKey(victim).hex))
+    }
+
+    /// Identity-key lookup must only return sessions that have been
+    /// verified. When both a claimed-only and a verified session exist
+    /// for the same identity key, only the verified one should be
+    /// reachable via identity lookup.
+    func testIdentityLookupOnlyReturnsVerifiedSessions() {
+        let manager = SessionManager()
+        let identity = PrivateKey.random()!
+        let identityHex = PublicKey.fromPrivateKey(identity).hex
+
+        // Attacker-seeded (responder path, unsigned initialRequest).
+        let unverified = makeSession(
+            sessionNonce: "unverified",
+            identity: identity,
+            peerIdentityKeyVerified: false,
+            lastUpdate: Date(timeIntervalSince1970: 2_000)
+        )
+        // Legitimate (initiator path — signature verified).
+        let verified = makeSession(
+            sessionNonce: "verified",
+            identity: identity,
+            peerIdentityKeyVerified: true,
+            lastUpdate: Date(timeIntervalSince1970: 1_000)
+        )
+        manager.addSession(unverified)
+        manager.addSession(verified)
+
+        // Even though the unverified session is more recent, only the
+        // verified one is reachable by identity-key lookup.
+        XCTAssertEqual(manager.getSession(identityHex)?.sessionNonce, "verified")
     }
 }

--- a/Tests/BSVTests/Overlay/HistorianTests.swift
+++ b/Tests/BSVTests/Overlay/HistorianTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import BSV
+
+final class HistorianTests: XCTestCase {
+
+    /// Build a simple chain: tip -> parent -> grandparent, each with one output
+    /// whose locking script is a 4-byte little-endian encoding of the value.
+    private func makeChain() -> Transaction {
+        func txWithValue(_ value: UInt32, parent: Transaction?) -> Transaction {
+            var data = Data(count: 4)
+            data.withUnsafeMutableBytes { bytes in
+                bytes.storeBytes(of: value.littleEndian, as: UInt32.self)
+            }
+            let output = TransactionOutput(
+                satoshis: 1,
+                lockingScript: Script(data: data)
+            )
+            var input = TransactionInput()
+            if let parent {
+                input.sourceTransaction = parent
+            }
+            return Transaction(
+                version: 1,
+                inputs: [input],
+                outputs: [output],
+                lockTime: 0
+            )
+        }
+
+        let grandparent = txWithValue(1, parent: nil)
+        let parent = txWithValue(2, parent: grandparent)
+        let tip = txWithValue(3, parent: parent)
+        return tip
+    }
+
+    func testBuildsChronologicalHistoryFromInputChain() async throws {
+        let tip = makeChain()
+        let historian = Historian<UInt32, String>(
+            interpreter: { tx, outputIndex, _ in
+                let data = tx.outputs[outputIndex].lockingScript.toBinary()
+                guard data.count == 4 else { return nil }
+                return data.withUnsafeBytes { $0.load(as: UInt32.self) }.littleEndian
+            }
+        )
+        let history = try await historian.buildHistory(startTransaction: tip)
+        XCTAssertEqual(history, [1, 2, 3])
+    }
+
+    func testCacheReusesPreviousResult() async throws {
+        let tip = makeChain()
+        var counter = 0
+        let historian = Historian<UInt32, String>(
+            interpreter: { tx, outputIndex, _ in
+                counter += 1
+                let data = tx.outputs[outputIndex].lockingScript.toBinary()
+                guard data.count == 4 else { return nil }
+                return data.withUnsafeBytes { $0.load(as: UInt32.self) }.littleEndian
+            },
+            enableCache: true
+        )
+        _ = try await historian.buildHistory(startTransaction: tip)
+        let callsAfterFirst = counter
+        _ = try await historian.buildHistory(startTransaction: tip)
+        XCTAssertEqual(counter, callsAfterFirst, "second build should hit the cache")
+    }
+}

--- a/Tests/BSVTests/Overlay/HostReputationTrackerTests.swift
+++ b/Tests/BSVTests/Overlay/HostReputationTrackerTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import BSV
+
+final class HostReputationTrackerTests: XCTestCase {
+
+    func testSuccessSeedsLatencyFromFirstSample() async {
+        let tracker = HostReputationTracker()
+        await tracker.recordSuccess(host: "https://a.example", latencyMs: 200)
+        let stats = await tracker.snapshot(for: "https://a.example")
+        XCTAssertEqual(stats.smoothedLatencyMs, 200, accuracy: 0.001)
+        XCTAssertEqual(stats.totalSuccesses, 1)
+        XCTAssertEqual(stats.consecutiveFailures, 0)
+    }
+
+    func testSubsequentSuccessSmoothesLatency() async {
+        let tracker = HostReputationTracker()
+        await tracker.recordSuccess(host: "host", latencyMs: 200)
+        await tracker.recordSuccess(host: "host", latencyMs: 400)
+        let stats = await tracker.snapshot(for: "host")
+        // EMA: 200 + 0.25*(400-200) = 250
+        XCTAssertEqual(stats.smoothedLatencyMs, 250, accuracy: 0.001)
+        XCTAssertEqual(stats.totalSuccesses, 2)
+    }
+
+    func testConsecutiveFailuresAccrueBackoffAfterGrace() async {
+        let tracker = HostReputationTracker()
+        // First two failures sit in the grace window.
+        await tracker.recordFailure(host: "host")
+        await tracker.recordFailure(host: "host")
+        var stats = await tracker.snapshot(for: "host")
+        XCTAssertEqual(stats.consecutiveFailures, 2)
+        XCTAssertNil(stats.backoffUntil)
+        // Third failure triggers back-off.
+        await tracker.recordFailure(host: "host")
+        stats = await tracker.snapshot(for: "host")
+        XCTAssertNotNil(stats.backoffUntil)
+        let inBackoff = await tracker.isInBackoff(host: "host")
+        XCTAssertTrue(inBackoff)
+    }
+
+    func testImmediateFailureBypassesGrace() async {
+        let tracker = HostReputationTracker()
+        await tracker.recordFailure(host: "host", immediate: true)
+        let inBackoff = await tracker.isInBackoff(host: "host")
+        XCTAssertTrue(inBackoff)
+    }
+
+    func testSuccessClearsBackoff() async {
+        let tracker = HostReputationTracker()
+        await tracker.recordFailure(host: "host", immediate: true)
+        await tracker.recordSuccess(host: "host", latencyMs: 120)
+        let stats = await tracker.snapshot(for: "host")
+        XCTAssertNil(stats.backoffUntil)
+        XCTAssertEqual(stats.consecutiveFailures, 0)
+    }
+
+    func testRankPrefersFasterHosts() async {
+        let tracker = HostReputationTracker()
+        await tracker.recordSuccess(host: "slow", latencyMs: 1000)
+        await tracker.recordSuccess(host: "fast", latencyMs: 50)
+        let ranked = await tracker.rank(hosts: ["slow", "fast"])
+        XCTAssertEqual(ranked, ["fast", "slow"])
+    }
+
+    func testRankDemotesFailingHosts() async {
+        let tracker = HostReputationTracker()
+        await tracker.recordSuccess(host: "good", latencyMs: 800)
+        await tracker.recordSuccess(host: "bad", latencyMs: 100)
+        // Push "bad" past the grace window so it accrues backoff.
+        for _ in 0..<5 {
+            await tracker.recordFailure(host: "bad")
+        }
+        let ranked = await tracker.rank(hosts: ["good", "bad"])
+        XCTAssertEqual(ranked.first, "good")
+    }
+}

--- a/Tests/BSVTests/Overlay/LookupResolverTests.swift
+++ b/Tests/BSVTests/Overlay/LookupResolverTests.swift
@@ -4,14 +4,19 @@ import XCTest
 /// A stub lookup facilitator that returns a canned response per host.
 actor StubLookupFacilitator: OverlayLookupFacilitator {
     let responses: [String: LookupAnswer]
+    let delays: [String: TimeInterval]
     private(set) var calls: [String] = []
 
-    init(responses: [String: LookupAnswer]) {
+    init(responses: [String: LookupAnswer], delays: [String: TimeInterval] = [:]) {
         self.responses = responses
+        self.delays = delays
     }
 
     func lookup(host: String, question: LookupQuestion, timeout: TimeInterval?) async throws -> LookupAnswer {
         calls.append(host)
+        if let delay = delays[host], delay > 0 {
+            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
         if let response = responses[host] { return response }
         throw OverlayError.networkFailure("no stub response for \(host)")
     }
@@ -68,6 +73,56 @@ final class LookupResolverTests: XCTestCase {
             query: Data()
         ))
         XCTAssertEqual(answer.outputs.count, 2)
+    }
+
+    /// Regression test for M3: the grace window must elapse on a timer, not
+    /// on the next `for await` iteration. If one host answers fast and the
+    /// rest are slow, `query` should return within roughly `graceWindow`
+    /// of the first answer — NOT wait for the slow hosts.
+    func testGraceWindowElapsesAgainstWallClockNotNextArrival() async throws {
+        let fastAnswer = LookupAnswer(outputs: [
+            LookupOutput(beef: Data([0x01]), outputIndex: 0)
+        ])
+        let slowAnswer = LookupAnswer(outputs: [
+            LookupOutput(beef: Data([0x02]), outputIndex: 0)
+        ])
+
+        // One host answers immediately, the other takes 3 seconds. With a
+        // 0.1s grace window the query must return in well under a second.
+        let facilitator = StubLookupFacilitator(
+            responses: [
+                "https://fast.example": fastAnswer,
+                "https://slow.example": slowAnswer
+            ],
+            delays: [
+                "https://fast.example": 0,
+                "https://slow.example": 3.0
+            ]
+        )
+        let resolver = LookupResolver(
+            hostResolver: StaticLookupHostResolver(hosts: [
+                "https://fast.example",
+                "https://slow.example"
+            ]),
+            facilitator: facilitator,
+            config: LookupResolverConfig(timeout: 10, graceWindow: 0.1)
+        )
+
+        let started = Date()
+        let answer = try await resolver.query(LookupQuestion(
+            service: "ls_demo",
+            query: Data()
+        ))
+        let elapsed = Date().timeIntervalSince(started)
+
+        // Must contain at least the fast answer. The slow answer may
+        // or may not have made it in depending on scheduling, but the
+        // critical property is that we did NOT wait the full 3s.
+        XCTAssertGreaterThanOrEqual(answer.outputs.count, 1)
+        XCTAssertLessThan(
+            elapsed, 1.0,
+            "query should return within ~graceWindow of first answer, not wait for slow hosts"
+        )
     }
 
     func testNoHostsThrows() async {

--- a/Tests/BSVTests/Overlay/LookupResolverTests.swift
+++ b/Tests/BSVTests/Overlay/LookupResolverTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import BSV
+
+/// A stub lookup facilitator that returns a canned response per host.
+actor StubLookupFacilitator: OverlayLookupFacilitator {
+    let responses: [String: LookupAnswer]
+    private(set) var calls: [String] = []
+
+    init(responses: [String: LookupAnswer]) {
+        self.responses = responses
+    }
+
+    func lookup(host: String, question: LookupQuestion, timeout: TimeInterval?) async throws -> LookupAnswer {
+        calls.append(host)
+        if let response = responses[host] { return response }
+        throw OverlayError.networkFailure("no stub response for \(host)")
+    }
+}
+
+/// Static host resolver for lookup tests.
+struct StaticLookupHostResolver: LookupHostResolver {
+    let hosts: [String]
+    func hosts(forService service: String) async throws -> [String] { hosts }
+}
+
+final class LookupResolverTests: XCTestCase {
+
+    func testRejectsServiceWithoutLsPrefix() async {
+        let facilitator = StubLookupFacilitator(responses: [:])
+        let resolver = LookupResolver(
+            hostResolver: StaticLookupHostResolver(hosts: []),
+            facilitator: facilitator,
+            config: LookupResolverConfig(graceWindow: 0)
+        )
+        do {
+            _ = try await resolver.query(LookupQuestion(service: "bad", query: Data()))
+            XCTFail("expected invalidServiceName")
+        } catch OverlayError.invalidServiceName {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testMergesResponsesFromMultipleHosts() async throws {
+        let answerA = LookupAnswer(outputs: [
+            LookupOutput(beef: Data([0x01]), outputIndex: 0)
+        ])
+        let answerB = LookupAnswer(outputs: [
+            LookupOutput(beef: Data([0x02]), outputIndex: 0),
+            // Duplicate of the A entry — should be deduplicated.
+            LookupOutput(beef: Data([0x01]), outputIndex: 0)
+        ])
+        let facilitator = StubLookupFacilitator(responses: [
+            "https://a.example": answerA,
+            "https://b.example": answerB
+        ])
+        let resolver = LookupResolver(
+            hostResolver: StaticLookupHostResolver(hosts: [
+                "https://a.example",
+                "https://b.example"
+            ]),
+            facilitator: facilitator,
+            config: LookupResolverConfig(graceWindow: 0.5)
+        )
+        let answer = try await resolver.query(LookupQuestion(
+            service: "ls_demo",
+            query: Data()
+        ))
+        XCTAssertEqual(answer.outputs.count, 2)
+    }
+
+    func testNoHostsThrows() async {
+        let facilitator = StubLookupFacilitator(responses: [:])
+        let resolver = LookupResolver(
+            hostResolver: StaticLookupHostResolver(hosts: []),
+            facilitator: facilitator
+        )
+        do {
+            _ = try await resolver.query(LookupQuestion(
+                service: "ls_demo",
+                query: Data()
+            ))
+            XCTFail("expected noHostsInterested")
+        } catch OverlayError.noHostsInterested {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/BSVTests/Overlay/OverlayAdminTokenTemplateTests.swift
+++ b/Tests/BSVTests/Overlay/OverlayAdminTokenTemplateTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import BSV
+
+final class OverlayAdminTokenTemplateTests: XCTestCase {
+
+    func testLockProducesDecodableSHIPAdvertisement() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let template = OverlayAdminTokenTemplate(wallet: wallet)
+
+        let script = try await template.lock(
+            protocol: .ship,
+            domain: "https://overlay.example",
+            topicOrService: "tm_demo"
+        )
+
+        let decoded = try OverlayAdminTokenTemplate.decode(script)
+        XCTAssertEqual(decoded.protocolKind, .ship)
+        XCTAssertEqual(decoded.domain, "https://overlay.example")
+        XCTAssertEqual(decoded.topicOrService, "tm_demo")
+
+        // identityKey should match the wallet's identity key in compressed hex.
+        let identity = try await wallet.getPublicKey(
+            args: GetPublicKeyArgs(identityKey: true)
+        ).publicKey
+        XCTAssertEqual(decoded.identityKey, identity.toCompressed().hex)
+    }
+
+    func testLockProducesDecodableSLAPAdvertisement() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let template = OverlayAdminTokenTemplate(wallet: wallet)
+
+        let script = try await template.lock(
+            protocol: .slap,
+            domain: "https://lookup.example",
+            topicOrService: "ls_demo"
+        )
+
+        let decoded = try OverlayAdminTokenTemplate.decode(script)
+        XCTAssertEqual(decoded.protocolKind, .slap)
+        XCTAssertEqual(decoded.domain, "https://lookup.example")
+        XCTAssertEqual(decoded.topicOrService, "ls_demo")
+    }
+
+    func testDecodeRejectsNonSHIPSLAPScripts() {
+        // Not long enough / wrong structure.
+        let script = Script(data: Data([OpCodes.OP_TRUE]))
+        XCTAssertThrowsError(try OverlayAdminTokenTemplate.decode(script))
+    }
+}

--- a/Tests/BSVTests/Overlay/SHIPBroadcasterTests.swift
+++ b/Tests/BSVTests/Overlay/SHIPBroadcasterTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import BSV
+
+/// A stub facilitator that records calls and returns a canned STEAK.
+actor StubBroadcastFacilitator: OverlayBroadcastFacilitator {
+    struct Call: Sendable {
+        let host: String
+        let topics: [String]
+    }
+    private(set) var calls: [Call] = []
+    private let response: STEAK
+    private let shouldFail: Set<String>
+
+    init(response: STEAK, failingHosts: Set<String> = []) {
+        self.response = response
+        self.shouldFail = failingHosts
+    }
+
+    func send(host: String, taggedBEEF: TaggedBEEF, timeout: TimeInterval?) async throws -> STEAK {
+        calls.append(Call(host: host, topics: taggedBEEF.topics))
+        if shouldFail.contains(host) {
+            throw OverlayError.networkFailure("stub failure")
+        }
+        return response
+    }
+}
+
+/// A simple resolver that maps topics to a fixed host list.
+struct StaticHostResolver: SHIPHostResolver {
+    let mapping: [String: [String]]
+    func hosts(forTopics topics: [String]) async throws -> [String: [String]] {
+        var result: [String: [String]] = [:]
+        for topic in topics {
+            result[topic] = mapping[topic] ?? []
+        }
+        return result
+    }
+}
+
+final class SHIPBroadcasterTests: XCTestCase {
+
+    func testRejectsTopicsWithoutTMPrefix() {
+        let resolver = StaticHostResolver(mapping: [:])
+        XCTAssertThrowsError(try SHIPBroadcaster(
+            topics: ["bad_topic"],
+            hostResolver: resolver
+        )) { error in
+            guard case OverlayError.invalidTopicPrefix = error else {
+                XCTFail("expected invalidTopicPrefix, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testAnyHostPolicyAcceptsSingleResponse() async throws {
+        let fac = StubBroadcastFacilitator(response: [
+            "tm_demo": AdmittanceInstructions(outputsToAdmit: [0])
+        ])
+        let resolver = StaticHostResolver(mapping: [
+            "tm_demo": ["https://host1.example", "https://host2.example"]
+        ])
+        let broadcaster = try SHIPBroadcaster(
+            topics: ["tm_demo"],
+            hostResolver: resolver,
+            facilitator: fac,
+            config: SHIPBroadcasterConfig(requirement: .anyHostForEachTopic),
+            timeout: nil
+        )
+        let tx = Transaction()
+        let response = try await broadcaster.broadcast(tx)
+        XCTAssertEqual(response.txid, tx.txid())
+        let calls = await fac.calls
+        XCTAssertEqual(calls.count, 2)
+    }
+
+    func testAllHostPolicyRequiresEveryHostToAcknowledge() async throws {
+        let fac = StubBroadcastFacilitator(
+            response: ["tm_demo": AdmittanceInstructions(outputsToAdmit: [0])],
+            failingHosts: ["https://flaky.example"]
+        )
+        let resolver = StaticHostResolver(mapping: [
+            "tm_demo": ["https://host1.example", "https://flaky.example"]
+        ])
+        let broadcaster = try SHIPBroadcaster(
+            topics: ["tm_demo"],
+            hostResolver: resolver,
+            facilitator: fac,
+            config: SHIPBroadcasterConfig(requirement: .allHostsForAllTopics),
+            timeout: nil
+        )
+        do {
+            _ = try await broadcaster.broadcast(Transaction())
+            XCTFail("expected acknowledgment failure")
+        } catch OverlayError.acknowledgmentFailure {
+            // expected
+        }
+    }
+
+    func testSpecificHostsPolicyChecksNamedHosts() async throws {
+        let fac = StubBroadcastFacilitator(response: [
+            "tm_demo": AdmittanceInstructions(outputsToAdmit: [0])
+        ])
+        let resolver = StaticHostResolver(mapping: [
+            "tm_demo": ["https://pinned.example", "https://other.example"]
+        ])
+        let broadcaster = try SHIPBroadcaster(
+            topics: ["tm_demo"],
+            hostResolver: resolver,
+            facilitator: fac,
+            config: SHIPBroadcasterConfig(
+                requirement: .specificHosts(["tm_demo": ["https://pinned.example"]])
+            ),
+            timeout: nil
+        )
+        _ = try await broadcaster.broadcast(Transaction())
+    }
+
+    func testNoHostsFails() async throws {
+        let fac = StubBroadcastFacilitator(response: [:])
+        let resolver = StaticHostResolver(mapping: ["tm_demo": []])
+        let broadcaster = try SHIPBroadcaster(
+            topics: ["tm_demo"],
+            hostResolver: resolver,
+            facilitator: fac,
+            config: SHIPBroadcasterConfig(),
+            timeout: nil
+        )
+        do {
+            _ = try await broadcaster.broadcast(Transaction())
+            XCTFail("expected noHostsInterested")
+        } catch OverlayError.noHostsInterested {
+            // expected
+        }
+    }
+}

--- a/Tests/BSVTests/Overlay/WithDoubleSpendRetryTests.swift
+++ b/Tests/BSVTests/Overlay/WithDoubleSpendRetryTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import BSV
+
+private struct StubDoubleSpendError: DoubleSpendReportingError {
+    let competingAction: DoubleSpendCompetingAction?
+}
+
+private struct PlainError: Error {}
+
+/// Stub broadcaster that records invocations but always succeeds.
+private actor CountingBroadcastFacilitator: OverlayBroadcastFacilitator {
+    private(set) var sendCount = 0
+    func send(host: String, taggedBEEF: TaggedBEEF, timeout: TimeInterval?) async throws -> STEAK {
+        sendCount += 1
+        return ["tm_demo": AdmittanceInstructions(outputsToAdmit: [0])]
+    }
+}
+
+private struct SingleHostResolver: SHIPHostResolver {
+    let host: String
+    func hosts(forTopics topics: [String]) async throws -> [String: [String]] {
+        var out: [String: [String]] = [:]
+        for topic in topics { out[topic] = [host] }
+        return out
+    }
+}
+
+final class WithDoubleSpendRetryTests: XCTestCase {
+
+    private func makeBroadcaster() throws -> (SHIPBroadcaster, CountingBroadcastFacilitator) {
+        let facilitator = CountingBroadcastFacilitator()
+        let broadcaster = try SHIPBroadcaster(
+            topics: ["tm_demo"],
+            hostResolver: SingleHostResolver(host: "https://a.example"),
+            facilitator: facilitator,
+            timeout: nil
+        )
+        return (broadcaster, facilitator)
+    }
+
+    func testSucceedsWithoutRetryIfOperationSucceeds() async throws {
+        let (broadcaster, _) = try makeBroadcaster()
+        let result = try await withDoubleSpendRetry(broadcaster: broadcaster) {
+            return 42
+        }
+        XCTAssertEqual(result, 42)
+    }
+
+    func testRethrowsNonDoubleSpendErrorImmediately() async throws {
+        let (broadcaster, _) = try makeBroadcaster()
+        do {
+            _ = try await withDoubleSpendRetry(broadcaster: broadcaster) {
+                throw PlainError()
+            }
+            XCTFail("expected PlainError")
+        } catch is PlainError {
+            // expected
+        }
+    }
+
+    func testRetriesWhenDoubleSpendWithoutCompetingAction() async throws {
+        let (broadcaster, _) = try makeBroadcaster()
+        do {
+            _ = try await withDoubleSpendRetry(broadcaster: broadcaster) {
+                throw StubDoubleSpendError(competingAction: nil)
+            }
+            XCTFail("expected StubDoubleSpendError")
+        } catch is StubDoubleSpendError {
+            // expected
+        }
+    }
+}

--- a/Tests/BSVTests/Overlay/WithDoubleSpendRetryTests.swift
+++ b/Tests/BSVTests/Overlay/WithDoubleSpendRetryTests.swift
@@ -69,4 +69,82 @@ final class WithDoubleSpendRetryTests: XCTestCase {
             // expected
         }
     }
+
+    /// Build a minimal valid BEEF binary wrapping a single raw transaction
+    /// so the retry helper can parse and rebroadcast it.
+    private func makeCompetingBeef() -> (Data, String) {
+        let tx = Transaction(version: 1, inputs: [], outputs: [], lockTime: 0)
+        let beef = Beef(
+            version: beefV2Version,
+            bumps: [],
+            transactions: [BeefTx(dataFormat: .rawTx, transaction: tx)]
+        )
+        return (beef.toBinary(), tx.txid())
+    }
+
+    /// An actor-backed counter so the retry operation closure, which is
+    /// `@Sendable`, can bump attempt count across retries.
+    private actor AttemptCounter {
+        private(set) var count = 0
+        func increment() -> Int {
+            count += 1
+            return count
+        }
+    }
+
+    func testRetriesAndSucceedsWithCompetingAction() async throws {
+        let (broadcaster, facilitator) = try makeBroadcaster()
+        let (beefBytes, txid) = makeCompetingBeef()
+        let attempts = AttemptCounter()
+
+        let result = try await withDoubleSpendRetry(broadcaster: broadcaster) {
+            let n = await attempts.increment()
+            if n == 1 {
+                throw StubDoubleSpendError(
+                    competingAction: DoubleSpendCompetingAction(
+                        beef: beefBytes,
+                        txid: txid
+                    )
+                )
+            }
+            return "ok"
+        }
+
+        XCTAssertEqual(result, "ok")
+        let attemptCount = await attempts.count
+        XCTAssertEqual(attemptCount, 2, "operation should run twice: once failing, once succeeding")
+        let sendCount = await facilitator.sendCount
+        XCTAssertEqual(sendCount, 1, "competing tx should be broadcast exactly once between attempts")
+    }
+
+    func testExhaustsMaxRetries() async throws {
+        let (broadcaster, facilitator) = try makeBroadcaster()
+        let (beefBytes, txid) = makeCompetingBeef()
+        let attempts = AttemptCounter()
+
+        do {
+            _ = try await withDoubleSpendRetry(
+                maxRetries: 3,
+                broadcaster: broadcaster
+            ) {
+                _ = await attempts.increment()
+                throw StubDoubleSpendError(
+                    competingAction: DoubleSpendCompetingAction(
+                        beef: beefBytes,
+                        txid: txid
+                    )
+                )
+            }
+            XCTFail("expected StubDoubleSpendError after exhausting retries")
+        } catch is StubDoubleSpendError {
+            // expected
+        }
+
+        let attemptCount = await attempts.count
+        XCTAssertEqual(attemptCount, 3, "operation should be attempted exactly maxRetries times")
+        // The final attempt short-circuits without broadcasting the competing
+        // tx (the retry loop only rebroadcasts when another attempt remains).
+        let sendCount = await facilitator.sendCount
+        XCTAssertEqual(sendCount, 2, "competing tx should be broadcast between each retry but not after the last failure")
+    }
 }

--- a/Tests/BSVTests/Primitives/ShamirTests.swift
+++ b/Tests/BSVTests/Primitives/ShamirTests.swift
@@ -1,0 +1,319 @@
+import XCTest
+@testable import BSV
+
+final class ShamirTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func randomKey() -> PrivateKey {
+        PrivateKey.random()!
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTrip3of5() throws {
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+        XCTAssertEqual(shares.points.count, 5)
+        XCTAssertEqual(shares.threshold, 3)
+
+        // Use the first 3 shares.
+        let subset = KeyShares(
+            points: Array(shares.points.prefix(3)),
+            threshold: shares.threshold,
+            integrity: shares.integrity
+        )
+        let recovered = try PrivateKey.fromKeyShares(subset)
+        XCTAssertEqual(recovered, key)
+    }
+
+    func testKnownKeyRoundTrip() throws {
+        // A specific, reproducible private key.
+        let key = PrivateKey(hex: "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35")!
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+        let recovered = try PrivateKey.fromKeyShares(
+            KeyShares(points: Array(shares.points.prefix(3)), threshold: 3, integrity: shares.integrity)
+        )
+        XCTAssertEqual(recovered, key)
+    }
+
+    // MARK: - Threshold enforcement
+
+    func testInsufficientSharesReconstruction() throws {
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+
+        // Only 2 shares — should throw.
+        let subset = KeyShares(
+            points: Array(shares.points.prefix(2)),
+            threshold: shares.threshold,
+            integrity: shares.integrity
+        )
+        XCTAssertThrowsError(try PrivateKey.fromKeyShares(subset)) { err in
+            guard case Shamir.Error.insufficientShares = err else {
+                XCTFail("Expected insufficientShares, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testReconstructionWithFewerThanThresholdFails() throws {
+        // If the caller lies about the number of shares by trimming threshold,
+        // the resulting key must differ (Shamir security property) — this is
+        // also indirectly checked by integrity-hash mismatch.
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+
+        // Pretend threshold is 2 using only 2 shares (lying): integrity check fails.
+        let subset = KeyShares(
+            points: Array(shares.points.prefix(2)),
+            threshold: 2,
+            integrity: shares.integrity
+        )
+        XCTAssertThrowsError(try PrivateKey.fromKeyShares(subset)) { err in
+            guard case Shamir.Error.integrityHashMismatch = err else {
+                XCTFail("Expected integrityHashMismatch, got \(err)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Order independence
+
+    func testOrderIndependence() throws {
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+
+        // Every 3-of-5 subset should reconstruct the same key.
+        let indices = [0, 1, 2, 3, 4]
+        var tried = 0
+        for i in 0..<indices.count {
+            for j in (i + 1)..<indices.count {
+                for k in (j + 1)..<indices.count {
+                    let subset = KeyShares(
+                        points: [shares.points[indices[i]], shares.points[indices[j]], shares.points[indices[k]]],
+                        threshold: shares.threshold,
+                        integrity: shares.integrity
+                    )
+                    let recovered = try PrivateKey.fromKeyShares(subset)
+                    XCTAssertEqual(recovered, key)
+                    tried += 1
+                }
+            }
+        }
+        XCTAssertEqual(tried, 10) // C(5, 3) = 10
+    }
+
+    func testShuffledOrderProducesSameKey() throws {
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+        let first3 = Array(shares.points.prefix(3))
+        let reversed = Array(first3.reversed())
+        let a = try PrivateKey.fromKeyShares(
+            KeyShares(points: first3, threshold: 3, integrity: shares.integrity)
+        )
+        let b = try PrivateKey.fromKeyShares(
+            KeyShares(points: reversed, threshold: 3, integrity: shares.integrity)
+        )
+        XCTAssertEqual(a, key)
+        XCTAssertEqual(b, key)
+    }
+
+    // MARK: - Multiple thresholds
+
+    func testMultipleThresholds() throws {
+        let configurations: [(threshold: Int, total: Int)] = [
+            (2, 3), (3, 5), (5, 7), (10, 15)
+        ]
+        for (t, n) in configurations {
+            let key = randomKey()
+            let shares = try key.toKeyShares(threshold: t, totalShares: n)
+            XCTAssertEqual(shares.points.count, n)
+            XCTAssertEqual(shares.threshold, t)
+            let subset = KeyShares(
+                points: Array(shares.points.prefix(t)),
+                threshold: t,
+                integrity: shares.integrity
+            )
+            let recovered = try PrivateKey.fromKeyShares(subset)
+            XCTAssertEqual(recovered, key, "failed for (threshold: \(t), total: \(n))")
+        }
+    }
+
+    // MARK: - Edge cases: threshold equals total
+
+    func testThresholdEqualsTotal() throws {
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 4, totalShares: 4)
+        let recovered = try PrivateKey.fromKeyShares(shares)
+        XCTAssertEqual(recovered, key)
+    }
+
+    // MARK: - Invalid parameters
+
+    func testThresholdTooLow() {
+        let key = randomKey()
+        XCTAssertThrowsError(try key.toKeyShares(threshold: 1, totalShares: 5)) { err in
+            XCTAssertEqual(err as? Shamir.Error, .thresholdTooLow)
+        }
+    }
+
+    func testTotalSharesTooLow() {
+        let key = randomKey()
+        XCTAssertThrowsError(try key.toKeyShares(threshold: 2, totalShares: 1)) { err in
+            XCTAssertEqual(err as? Shamir.Error, .totalSharesTooLow)
+        }
+    }
+
+    func testThresholdExceedsTotal() {
+        let key = randomKey()
+        XCTAssertThrowsError(try key.toKeyShares(threshold: 5, totalShares: 3)) { err in
+            XCTAssertEqual(err as? Shamir.Error, .thresholdExceedsTotal)
+        }
+    }
+
+    // MARK: - Duplicate share detection
+
+    func testDuplicateShareDetected() throws {
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+        let dup = KeyShares(
+            points: [shares.points[0], shares.points[1], shares.points[1]],
+            threshold: 3,
+            integrity: shares.integrity
+        )
+        XCTAssertThrowsError(try PrivateKey.fromKeyShares(dup)) { err in
+            XCTAssertEqual(err as? Shamir.Error, .duplicateShare)
+        }
+    }
+
+    // MARK: - KeyShares serialisation round-trip
+
+    func testBackupFormatRoundTrip() throws {
+        let key = randomKey()
+        let shares = try key.toKeyShares(threshold: 3, totalShares: 5)
+        let backup = shares.toBackupFormat()
+        XCTAssertEqual(backup.count, 5)
+
+        for s in backup {
+            let parts = s.split(separator: ".")
+            XCTAssertEqual(parts.count, 4, "expected x.y.threshold.integrity")
+            XCTAssertEqual(String(parts[2]), "3")
+            XCTAssertEqual(String(parts[3]), shares.integrity)
+        }
+
+        let parsed = try KeyShares.fromBackupFormat(Array(backup.prefix(3)))
+        XCTAssertEqual(parsed.threshold, 3)
+        XCTAssertEqual(parsed.integrity, shares.integrity)
+        XCTAssertEqual(parsed.points.count, 3)
+
+        let recovered = try PrivateKey.fromKeyShares(parsed)
+        XCTAssertEqual(recovered, key)
+    }
+
+    func testToBackupSharesAndFromBackupShares() throws {
+        let key = randomKey()
+        let backup = try key.toBackupShares(threshold: 3, totalShares: 5)
+        let recovered = try PrivateKey.fromBackupShares(Array(backup.prefix(3)))
+        XCTAssertEqual(recovered, key)
+    }
+
+    func testBackupFormatRejectsMalformedShare() {
+        XCTAssertThrowsError(try KeyShares.fromBackupFormat(["not-a-share"])) { err in
+            XCTAssertEqual(err as? Shamir.Error, .invalidShareFormat)
+        }
+    }
+
+    func testBackupFormatRejectsMismatchedThreshold() throws {
+        let key = randomKey()
+        let backup = try key.toBackupShares(threshold: 3, totalShares: 5)
+        // Tamper with the threshold on the second share.
+        var tampered = backup
+        let parts = tampered[1].split(separator: ".").map(String.init)
+        tampered[1] = "\(parts[0]).\(parts[1]).4.\(parts[3])"
+
+        XCTAssertThrowsError(try KeyShares.fromBackupFormat(Array(tampered.prefix(3)))) { err in
+            XCTAssertEqual(err as? Shamir.Error, .thresholdMismatch)
+        }
+    }
+
+    func testBackupFormatRejectsMismatchedIntegrity() throws {
+        let key = randomKey()
+        let backup = try key.toBackupShares(threshold: 3, totalShares: 5)
+        // Tamper with the integrity on the second share.
+        var tampered = backup
+        let parts = tampered[1].split(separator: ".").map(String.init)
+        tampered[1] = "\(parts[0]).\(parts[1]).\(parts[2]).deadbeef"
+
+        XCTAssertThrowsError(try KeyShares.fromBackupFormat(Array(tampered.prefix(3)))) { err in
+            XCTAssertEqual(err as? Shamir.Error, .integrityMismatch)
+        }
+    }
+
+    // MARK: - Cross-SDK compatibility
+
+    /// Decode a known-good share bundle from the ts-sdk test suite and verify
+    /// it can be parsed. The shares themselves come from ts-sdk's
+    /// PrivateKey.split.test.ts so the format must be interoperable.
+    func testTsSDKShareBundleParses() throws {
+        let backup = [
+            "45s4vLL2hFvqmxrarvbRT2vZoQYGZGocsmaEksZ64o5M.A7nZrGux15nEsQGNZ1mbfnMKugNnS6SYYEQwfhfbDZG8.3.2f804d43",
+            "7aPzkiGZgvU4Jira5PN9Qf9o7FEg6uwy1zcxd17NBhh3.CCt7NH1sPFgceb6phTRkfviim2WvmUycJCQd2BxauxP9.3.2f804d43",
+            "9GaS2Tw5sXqqbuigdjwGPwPsQuEFqzqUXo5MAQhdK3es.8MLh2wyE3huyq6hiBXjSkJRucgyKh4jVY6ESq5jNtXRE.3.2f804d43",
+            "GBmoNRbsMVsLmEK5A6G28fktUNonZkn9mDrJJ58FXgsf.HDBRkzVUCtZ38ApEu36fvZtDoDSQTv3TWmbnxwwR7kto.3.2f804d43",
+            "2gHebXBgPd7daZbsj6w9TPDta3vQzqvbkLtJG596rdN1.E7ZaHyyHNDCwR6qxZvKkPPWWXzFCiKQFentJtvSSH5Bi.3.2f804d43"
+        ]
+        let shares = try KeyShares.fromBackupFormat(backup)
+        XCTAssertEqual(shares.threshold, 3)
+        XCTAssertEqual(shares.integrity, "2f804d43")
+        XCTAssertEqual(shares.points.count, 5)
+
+        // Reconstruct using any 3 of the 5 — expect a valid private key whose
+        // hash160 prefix matches the integrity tag.
+        let subset = KeyShares(
+            points: Array(shares.points.prefix(3)),
+            threshold: 3,
+            integrity: "2f804d43"
+        )
+        let key = try PrivateKey.fromKeyShares(subset)
+
+        // Reconstructing from a different 3-subset must yield the same key.
+        let subset2 = KeyShares(
+            points: Array(shares.points.suffix(3)),
+            threshold: 3,
+            integrity: "2f804d43"
+        )
+        let key2 = try PrivateKey.fromKeyShares(subset2)
+        XCTAssertEqual(key, key2)
+    }
+
+    // MARK: - Serialisation of points
+
+    func testPointInFiniteFieldToStringRoundTrip() throws {
+        var xBytes = Data(count: 32); xBytes[30] = 0x01; xBytes[31] = 0x23
+        var yBytes = Data(count: 32); yBytes[30] = 0xAB; yBytes[31] = 0xCD
+        let point = PointInFiniteField(x: xBytes, y: yBytes)
+        let encoded = point.toString()
+        let decoded = try PointInFiniteField.fromString(encoded)
+        XCTAssertEqual(decoded.x, point.x)
+        XCTAssertEqual(decoded.y, point.y)
+    }
+
+    // MARK: - FieldP sanity checks
+
+    func testFieldPAddSubInverseIdentity() {
+        let a = Data(hex: "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35")!
+        let b = Data(hex: "123456789abcdef0fedcba9876543210cafebabedeadbeef0badf00dfeedface")!
+
+        // (a + b) - b == a (mod P)
+        let sum = FieldP.add(a, b)
+        let recovered = FieldP.sub(sum, b)
+        XCTAssertEqual(recovered, a)
+
+        // a * a^(-1) == 1
+        let inv = FieldP.inverse(a)
+        let product = FieldP.mul(a, inv)
+        var one = Data(count: 32); one[31] = 1
+        XCTAssertEqual(product, one)
+    }
+}

--- a/Tests/BSVTests/Wallet/CachedKeyDeriverTests.swift
+++ b/Tests/BSVTests/Wallet/CachedKeyDeriverTests.swift
@@ -1,0 +1,219 @@
+import XCTest
+@testable import BSV
+
+/// Tests for `CachedKeyDeriver`.
+///
+/// Covers cache correctness (hit returns the same value as a fresh call,
+/// different arguments don't collide), LRU eviction ordering when the
+/// cache fills up, and concurrent access under contention.
+final class CachedKeyDeriverTests: XCTestCase {
+
+    private func makeDeriver(maxCacheSize: Int = 1000) -> (CachedKeyDeriver, KeyDeriver) {
+        let root = PrivateKey.random()!
+        let cached = CachedKeyDeriver(rootKey: root, maxCacheSize: maxCacheSize)
+        let uncached = KeyDeriver(rootKey: root)
+        return (cached, uncached)
+    }
+
+    private var testProtocol: WalletProtocol {
+        WalletProtocol(securityLevel: .app, protocol: "cached keyderiver test")
+    }
+
+    // MARK: - Correctness
+
+    func testCacheHitMatchesUncachedResult() throws {
+        let (cached, uncached) = makeDeriver()
+        let counterparty = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        let first = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "1", counterparty: counterparty
+        )
+        let second = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "1", counterparty: counterparty
+        )
+        let reference = try uncached.derivePublicKey(
+            protocolID: testProtocol, keyID: "1", counterparty: counterparty
+        )
+
+        XCTAssertEqual(first.hex, reference.hex)
+        XCTAssertEqual(second.hex, reference.hex, "second call should be served from cache")
+    }
+
+    func testDifferentKeyIDsDoNotCollide() throws {
+        let (cached, _) = makeDeriver()
+        let counterparty = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        let a = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "a", counterparty: counterparty
+        )
+        let b = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "b", counterparty: counterparty
+        )
+        XCTAssertNotEqual(a.hex, b.hex)
+    }
+
+    func testDifferentCounterpartiesDoNotCollide() throws {
+        let (cached, _) = makeDeriver()
+        let cp1 = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+        let cp2 = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        let a = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "x", counterparty: cp1
+        )
+        let b = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "x", counterparty: cp2
+        )
+        XCTAssertNotEqual(a.hex, b.hex)
+    }
+
+    func testForSelfDiscriminatesCacheEntries() throws {
+        let (cached, _) = makeDeriver()
+        let counterparty = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        let forSelf = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "1", counterparty: counterparty, forSelf: true
+        )
+        let forOther = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "1", counterparty: counterparty, forSelf: false
+        )
+        XCTAssertNotEqual(forSelf.hex, forOther.hex)
+    }
+
+    func testPrivateAndPublicCachesDoNotCollide() throws {
+        let (cached, _) = makeDeriver()
+        let counterparty = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        _ = try cached.derivePrivateKey(
+            protocolID: testProtocol, keyID: "1", counterparty: counterparty
+        )
+        // Must still return a PublicKey, not fail an internal type cast.
+        let pub = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "1", counterparty: counterparty, forSelf: true
+        )
+        XCTAssertFalse(pub.hex.isEmpty)
+    }
+
+    // MARK: - LRU eviction
+
+    func testLRUEvictsLeastRecentlyUsedWhenFull() throws {
+        // maxCacheSize = 3, insert four keys — the first one must be evicted.
+        let (cached, _) = makeDeriver(maxCacheSize: 3)
+        let counterparty = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        // Insert four distinct keys: a, b, c, d. "a" should be evicted.
+        for keyID in ["a", "b", "c", "d"] {
+            _ = try cached.derivePublicKey(
+                protocolID: testProtocol, keyID: keyID, counterparty: counterparty
+            )
+        }
+
+        // Probe the cache indirectly: override inner by checking whether
+        // hits touch state. Inspect via reflection of the private lookup.
+        let mirror = Mirror(reflecting: cached)
+        let lookupChild = mirror.children.first { $0.label == "lookup" }
+        XCTAssertNotNil(lookupChild)
+        let lookup = lookupChild?.value as? [String: Any] ?? [:]
+        XCTAssertEqual(lookup.count, 3, "cache size must be capped at maxCacheSize")
+
+        // The evicted entry must be the least recent one ("a").
+        let keys = lookup.keys.map { $0 }
+        XCTAssertFalse(keys.contains(where: { $0.contains("|a|") }), "oldest key should be evicted")
+        XCTAssertTrue(keys.contains(where: { $0.contains("|b|") }))
+        XCTAssertTrue(keys.contains(where: { $0.contains("|c|") }))
+        XCTAssertTrue(keys.contains(where: { $0.contains("|d|") }))
+    }
+
+    func testLRUAccessOrderPromotesRecency() throws {
+        // maxCacheSize = 3. Insert a, b, c. Touch "a" again. Insert d.
+        // Now "b" (not "a") should be evicted.
+        let (cached, _) = makeDeriver(maxCacheSize: 3)
+        let counterparty = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        for keyID in ["a", "b", "c"] {
+            _ = try cached.derivePublicKey(
+                protocolID: testProtocol, keyID: keyID, counterparty: counterparty
+            )
+        }
+        // Touch "a" — it should now be the most-recent entry.
+        _ = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "a", counterparty: counterparty
+        )
+        // Insert "d" — "b" (now the oldest) should be evicted.
+        _ = try cached.derivePublicKey(
+            protocolID: testProtocol, keyID: "d", counterparty: counterparty
+        )
+
+        let mirror = Mirror(reflecting: cached)
+        let lookupChild = mirror.children.first { $0.label == "lookup" }
+        let lookup = lookupChild?.value as? [String: Any] ?? [:]
+        XCTAssertEqual(lookup.count, 3)
+        let keys = lookup.keys.map { $0 }
+        XCTAssertTrue(keys.contains(where: { $0.contains("|a|") }), "recently accessed 'a' must survive")
+        XCTAssertFalse(keys.contains(where: { $0.contains("|b|") }), "'b' must be evicted as the new LRU")
+        XCTAssertTrue(keys.contains(where: { $0.contains("|c|") }))
+        XCTAssertTrue(keys.contains(where: { $0.contains("|d|") }))
+    }
+
+    // MARK: - Concurrency
+
+    func testConcurrentAccessIsSafe() throws {
+        let (cached, _) = makeDeriver(maxCacheSize: 32)
+        let counterparty = WalletCounterparty.publicKey(
+            PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+
+        // Fire 200 concurrent derivations across 50 distinct keys so some
+        // calls hit the cache and some force eviction. This should not
+        // crash or deadlock under TSan.
+        final class ErrorBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _error: Error?
+            var error: Error? {
+                lock.lock(); defer { lock.unlock() }
+                return _error
+            }
+            func set(_ e: Error) {
+                lock.lock(); defer { lock.unlock() }
+                if _error == nil { _error = e }
+            }
+        }
+        let errors = ErrorBox()
+
+        let group = DispatchGroup()
+        let queue = DispatchQueue.global(qos: .userInitiated)
+        let proto = testProtocol
+        for i in 0..<200 {
+            group.enter()
+            queue.async {
+                defer { group.leave() }
+                do {
+                    _ = try cached.derivePublicKey(
+                        protocolID: proto,
+                        keyID: "key-\(i % 50)",
+                        counterparty: counterparty
+                    )
+                } catch {
+                    errors.set(error)
+                }
+            }
+        }
+        group.wait()
+        XCTAssertNil(errors.error)
+    }
+}

--- a/Tests/BSVTests/Wallet/KeyDeriverTests.swift
+++ b/Tests/BSVTests/Wallet/KeyDeriverTests.swift
@@ -38,7 +38,7 @@ final class KeyDeriverTests: XCTestCase {
             let recipient = PrivateKey(hex: vector.recipientPrivateKey)!
             let sender = PublicKey(hex: vector.senderPublicKey)!
 
-            let derivedPrivate = KeyDeriver(rootKey: recipient).deriveChildPrivate(
+            let derivedPrivate = try KeyDeriver(rootKey: recipient).deriveChildPrivate(
                 priv: recipient,
                 counterpartyPub: sender,
                 invoiceNumber: vector.invoiceNumber
@@ -59,7 +59,7 @@ final class KeyDeriverTests: XCTestCase {
             let sender = PrivateKey(hex: vector.senderPrivateKey)!
             let recipient = PublicKey(hex: vector.recipientPublicKey)!
 
-            let derivedPublic = KeyDeriver(rootKey: sender).deriveChildPublic(
+            let derivedPublic = try KeyDeriver(rootKey: sender).deriveChildPublic(
                 pub: recipient,
                 counterpartyPriv: sender,
                 invoiceNumber: vector.invoiceNumber

--- a/Tests/BSVTests/Wallet/KeyDeriverTests.swift
+++ b/Tests/BSVTests/Wallet/KeyDeriverTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import BSV
+
+/// Tests for BRC-42 key derivation, including the shared vectors from the
+/// other BSV SDKs (`Tests/BSVTests/Conformance/Vectors/BRC42.{private,public}.vectors.json`).
+final class KeyDeriverTests: XCTestCase {
+
+    // MARK: - Shared vectors
+
+    private struct PrivateVector: Decodable {
+        let senderPublicKey: String
+        let recipientPrivateKey: String
+        let invoiceNumber: String
+        let privateKey: String
+    }
+
+    private struct PublicVector: Decodable {
+        let senderPrivateKey: String
+        let recipientPublicKey: String
+        let invoiceNumber: String
+        let publicKey: String
+    }
+
+    private func loadVectors<T: Decodable>(_ name: String, as type: T.Type) throws -> T {
+        let url = try XCTUnwrap(
+            Bundle.module.url(forResource: name, withExtension: "json", subdirectory: "Vectors"),
+            "missing test vector file: \(name).json"
+        )
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    func testBRC42PrivateKeyVectors() throws {
+        let vectors = try loadVectors("BRC42.private.vectors", as: [PrivateVector].self)
+        XCTAssertFalse(vectors.isEmpty)
+
+        for vector in vectors {
+            let recipient = PrivateKey(hex: vector.recipientPrivateKey)!
+            let sender = PublicKey(hex: vector.senderPublicKey)!
+
+            let derivedPrivate = KeyDeriver(rootKey: recipient).deriveChildPrivate(
+                priv: recipient,
+                counterpartyPub: sender,
+                invoiceNumber: vector.invoiceNumber
+            )
+            XCTAssertEqual(
+                derivedPrivate.hex,
+                vector.privateKey,
+                "BRC-42 private derivation mismatch for invoice \(vector.invoiceNumber)"
+            )
+        }
+    }
+
+    func testBRC42PublicKeyVectors() throws {
+        let vectors = try loadVectors("BRC42.public.vectors", as: [PublicVector].self)
+        XCTAssertFalse(vectors.isEmpty)
+
+        for vector in vectors {
+            let sender = PrivateKey(hex: vector.senderPrivateKey)!
+            let recipient = PublicKey(hex: vector.recipientPublicKey)!
+
+            let derivedPublic = KeyDeriver(rootKey: sender).deriveChildPublic(
+                pub: recipient,
+                counterpartyPriv: sender,
+                invoiceNumber: vector.invoiceNumber
+            )
+            XCTAssertEqual(
+                derivedPublic.hex,
+                vector.publicKey,
+                "BRC-42 public derivation mismatch for invoice \(vector.invoiceNumber)"
+            )
+        }
+    }
+
+    // MARK: - High-level derive API
+
+    func testDerivePublicKeyMatchesDerivePrivateKey() throws {
+        let root = PrivateKey.random()!
+        let counterparty = PrivateKey.random()!
+        let deriver = KeyDeriver(rootKey: root)
+
+        let proto = WalletProtocol(securityLevel: .app, protocol: "test protocolname")
+        let counterpartyCp = WalletCounterparty.publicKey(PublicKey.fromPrivateKey(counterparty))
+
+        // Deriving for self: the derived public key must equal priv * G.
+        let selfPriv = try deriver.derivePrivateKey(
+            protocolID: proto,
+            keyID: "1",
+            counterparty: counterpartyCp
+        )
+        let selfPub = try deriver.derivePublicKey(
+            protocolID: proto,
+            keyID: "1",
+            counterparty: counterpartyCp,
+            forSelf: true
+        )
+        XCTAssertEqual(PublicKey.fromPrivateKey(selfPriv), selfPub)
+    }
+
+    func testDeriveSymmetricKeyIsSymmetric() throws {
+        // Two parties derive the same symmetric key from opposite viewpoints.
+        let alice = PrivateKey.random()!
+        let bob = PrivateKey.random()!
+        let aliceDeriver = KeyDeriver(rootKey: alice)
+        let bobDeriver = KeyDeriver(rootKey: bob)
+
+        let proto = WalletProtocol(securityLevel: .counterparty, protocol: "shared symmetric")
+
+        let aliceKey = try aliceDeriver.deriveSymmetricKey(
+            protocolID: proto,
+            keyID: "message-1",
+            counterparty: .publicKey(PublicKey.fromPrivateKey(bob))
+        )
+        let bobKey = try bobDeriver.deriveSymmetricKey(
+            protocolID: proto,
+            keyID: "message-1",
+            counterparty: .publicKey(PublicKey.fromPrivateKey(alice))
+        )
+        XCTAssertEqual(aliceKey.key, bobKey.key)
+    }
+
+    // MARK: - Invoice number validation
+
+    func testRejectsEmptyKeyID() {
+        let deriver = KeyDeriver(rootKey: PrivateKey.random()!)
+        let proto = WalletProtocol(securityLevel: .silent, protocol: "valid name")
+        XCTAssertThrowsError(
+            try deriver.computeInvoiceNumber(protocolID: proto, keyID: "")
+        )
+    }
+
+    func testRejectsShortProtocolName() {
+        let deriver = KeyDeriver(rootKey: PrivateKey.random()!)
+        let proto = WalletProtocol(securityLevel: .silent, protocol: "abc")
+        XCTAssertThrowsError(
+            try deriver.computeInvoiceNumber(protocolID: proto, keyID: "1")
+        )
+    }
+
+    func testRejectsProtocolNameEndingInProtocol() {
+        let deriver = KeyDeriver(rootKey: PrivateKey.random()!)
+        let proto = WalletProtocol(securityLevel: .silent, protocol: "something protocol")
+        XCTAssertThrowsError(
+            try deriver.computeInvoiceNumber(protocolID: proto, keyID: "1")
+        )
+    }
+
+    func testRejectsDoubleSpacesInProtocolName() {
+        let deriver = KeyDeriver(rootKey: PrivateKey.random()!)
+        let proto = WalletProtocol(securityLevel: .silent, protocol: "two  spaces")
+        XCTAssertThrowsError(
+            try deriver.computeInvoiceNumber(protocolID: proto, keyID: "1")
+        )
+    }
+
+    func testAcceptsValidBRC43InvoiceNumber() throws {
+        let deriver = KeyDeriver(rootKey: PrivateKey.random()!)
+        let proto = WalletProtocol(securityLevel: .app, protocol: "test protocol name")
+        let invoice = try deriver.computeInvoiceNumber(protocolID: proto, keyID: "42")
+        XCTAssertEqual(invoice, "1-test protocol name-42")
+    }
+
+    // MARK: - Counterparty secrets
+
+    func testRevealCounterpartySecretRejectsSelf() {
+        let deriver = KeyDeriver(rootKey: PrivateKey.random()!)
+        XCTAssertThrowsError(try deriver.revealCounterpartySecret(counterparty: .`self`))
+    }
+}

--- a/Tests/BSVTests/Wallet/ProtoWalletTests.swift
+++ b/Tests/BSVTests/Wallet/ProtoWalletTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+@testable import BSV
+
+final class ProtoWalletTests: XCTestCase {
+
+    private func makeProtocol() -> WalletProtocol {
+        WalletProtocol(securityLevel: .app, protocol: "wallet tests")
+    }
+
+    // MARK: - Identity
+
+    func testGetIdentityPublicKey() async throws {
+        let root = PrivateKey.random()!
+        let wallet = ProtoWallet(rootKey: root)
+
+        let identity = try await wallet.getPublicKey(args: GetPublicKeyArgs(identityKey: true))
+        XCTAssertEqual(identity.publicKey, PublicKey.fromPrivateKey(root))
+    }
+
+    func testGetPublicKeyRequiresEncryptionArgs() async {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        do {
+            _ = try await wallet.getPublicKey(args: GetPublicKeyArgs(identityKey: false))
+            XCTFail("expected invalidParameter")
+        } catch let err as WalletError {
+            if case .invalidParameter = err { } else { XCTFail("unexpected error: \(err)") }
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Encryption round-trip
+
+    func testEncryptDecryptRoundTrip() async throws {
+        let alice = ProtoWallet(rootKey: PrivateKey.random()!)
+        let bob = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let aliceIdentity = (try await alice.getPublicKey(args: GetPublicKeyArgs(identityKey: true))).publicKey
+        let bobIdentity = (try await bob.getPublicKey(args: GetPublicKeyArgs(identityKey: true))).publicKey
+
+        let proto = makeProtocol()
+        let aliceToBobArgs = WalletEncryptionArgs(
+            protocolID: proto,
+            keyID: "message-1",
+            counterparty: .publicKey(bobIdentity)
+        )
+        let bobToAliceArgs = WalletEncryptionArgs(
+            protocolID: proto,
+            keyID: "message-1",
+            counterparty: .publicKey(aliceIdentity)
+        )
+
+        let plaintext = "BRC-100 round-trip".data(using: .utf8)!
+        let ciphertext = try await alice.encrypt(
+            args: WalletEncryptArgs(encryption: aliceToBobArgs, plaintext: plaintext)
+        ).ciphertext
+
+        let recovered = try await bob.decrypt(
+            args: WalletDecryptArgs(encryption: bobToAliceArgs, ciphertext: ciphertext)
+        ).plaintext
+
+        XCTAssertEqual(recovered, plaintext)
+    }
+
+    func testEncryptDecryptSelf() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let args = WalletEncryptionArgs(protocolID: makeProtocol(), keyID: "self", counterparty: .`self`)
+
+        let plaintext = Data([0x01, 0x02, 0x03, 0xff])
+        let ciphertext = try await wallet.encrypt(
+            args: WalletEncryptArgs(encryption: args, plaintext: plaintext)
+        ).ciphertext
+        let recovered = try await wallet.decrypt(
+            args: WalletDecryptArgs(encryption: args, ciphertext: ciphertext)
+        ).plaintext
+        XCTAssertEqual(recovered, plaintext)
+    }
+
+    // MARK: - HMAC
+
+    func testHmacCreateVerify() async throws {
+        let alice = ProtoWallet(rootKey: PrivateKey.random()!)
+        let bob = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let aliceIdentity = (try await alice.getPublicKey(args: GetPublicKeyArgs(identityKey: true))).publicKey
+        let bobIdentity = (try await bob.getPublicKey(args: GetPublicKeyArgs(identityKey: true))).publicKey
+
+        let proto = makeProtocol()
+        let payload = "hello".data(using: .utf8)!
+
+        let mac = try await alice.createHmac(args: CreateHmacArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: proto,
+                keyID: "hmac-1",
+                counterparty: .publicKey(bobIdentity)
+            ),
+            data: payload
+        )).hmac
+
+        let ok = try await bob.verifyHmac(args: VerifyHmacArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: proto,
+                keyID: "hmac-1",
+                counterparty: .publicKey(aliceIdentity)
+            ),
+            data: payload,
+            hmac: mac
+        )).valid
+        XCTAssertTrue(ok)
+    }
+
+    func testVerifyHmacFailsForTamperedData() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let args = WalletEncryptionArgs(protocolID: makeProtocol(), keyID: "h", counterparty: .`self`)
+
+        let mac = try await wallet.createHmac(args: CreateHmacArgs(
+            encryption: args,
+            data: "original".data(using: .utf8)!
+        )).hmac
+
+        do {
+            _ = try await wallet.verifyHmac(args: VerifyHmacArgs(
+                encryption: args,
+                data: "tampered".data(using: .utf8)!,
+                hmac: mac
+            ))
+            XCTFail("expected invalidHmac")
+        } catch WalletError.invalidHmac {
+            // expected
+        }
+    }
+
+    // MARK: - Signature
+
+    func testSignatureCreateVerifyToSelf() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let enc = WalletEncryptionArgs(protocolID: makeProtocol(), keyID: "sig-1", counterparty: .`self`)
+
+        let message = "sign me".data(using: .utf8)!
+        let sig = try await wallet.createSignature(args: CreateSignatureArgs(
+            encryption: enc, data: message
+        )).signature
+
+        let ok = try await wallet.verifySignature(args: VerifySignatureArgs(
+            encryption: enc,
+            signature: sig,
+            data: message,
+            forSelf: true
+        )).valid
+        XCTAssertTrue(ok)
+    }
+
+    func testSignatureCreateToCounterpartyVerify() async throws {
+        let alice = ProtoWallet(rootKey: PrivateKey.random()!)
+        let bob = ProtoWallet(rootKey: PrivateKey.random()!)
+
+        let aliceIdentity = (try await alice.getPublicKey(args: GetPublicKeyArgs(identityKey: true))).publicKey
+        let bobIdentity = (try await bob.getPublicKey(args: GetPublicKeyArgs(identityKey: true))).publicKey
+
+        let proto = makeProtocol()
+        let message = "authenticated".data(using: .utf8)!
+
+        // Alice signs a message intended for Bob.
+        let sig = try await alice.createSignature(args: CreateSignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: proto,
+                keyID: "authkey",
+                counterparty: .publicKey(bobIdentity)
+            ),
+            data: message
+        )).signature
+
+        // Bob verifies the signature using Alice as the counterparty.
+        let ok = try await bob.verifySignature(args: VerifySignatureArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: proto,
+                keyID: "authkey",
+                counterparty: .publicKey(aliceIdentity)
+            ),
+            signature: sig,
+            data: message,
+            forSelf: false
+        )).valid
+        XCTAssertTrue(ok)
+    }
+
+    func testSignatureRequiresOneOfDataOrHash() async {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let enc = WalletEncryptionArgs(protocolID: makeProtocol(), keyID: "sig", counterparty: .`self`)
+
+        // Neither provided.
+        do {
+            _ = try await wallet.createSignature(args: CreateSignatureArgs(encryption: enc))
+            XCTFail("expected invalidParameter")
+        } catch WalletError.invalidParameter {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+
+        // Both provided.
+        do {
+            _ = try await wallet.createSignature(args: CreateSignatureArgs(
+                encryption: enc,
+                data: Data(repeating: 0x01, count: 10),
+                hashToDirectlySign: Data(repeating: 0x02, count: 32)
+            ))
+            XCTFail("expected invalidParameter")
+        } catch WalletError.invalidParameter {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Linkage
+
+    func testRevealCounterpartyKeyLinkageNotSupported() async {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let args = RevealCounterpartyKeyLinkageArgs(
+            counterparty: PublicKey.fromPrivateKey(PrivateKey.random()!),
+            verifier: PublicKey.fromPrivateKey(PrivateKey.random()!)
+        )
+        do {
+            _ = try await wallet.revealCounterpartyKeyLinkage(args: args)
+            XCTFail("expected unsupportedAction")
+        } catch WalletError.unsupportedAction {
+            // expected
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testRevealSpecificKeyLinkageRoundTrip() async throws {
+        let wallet = ProtoWallet(rootKey: PrivateKey.random()!)
+        let counterparty = PublicKey.fromPrivateKey(PrivateKey.random()!)
+        let verifier = PublicKey.fromPrivateKey(PrivateKey.random()!)
+
+        let result = try await wallet.revealSpecificKeyLinkage(args: RevealSpecificKeyLinkageArgs(
+            counterparty: .publicKey(counterparty),
+            verifier: verifier,
+            protocolID: makeProtocol(),
+            keyID: "linkage-1"
+        ))
+        XCTAssertEqual(result.verifier, verifier)
+        XCTAssertEqual(result.keyID, "linkage-1")
+        XCTAssertFalse(result.encryptedLinkage.isEmpty)
+    }
+}

--- a/Tests/BSVTests/Wallet/WalletClientTests.swift
+++ b/Tests/BSVTests/Wallet/WalletClientTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import BSV
+
+final class WalletClientTests: XCTestCase {
+
+    /// A substrate that captures the last request and returns a scripted response.
+    final class MockSubstrate: WalletSubstrate, @unchecked Sendable {
+        var lastMethod: String?
+        var lastBody: [String: Any]?
+        var lastOriginator: String?
+        var response: [String: Any] = [:]
+        var error: Error?
+
+        func invoke(method: String, body: Data, originator: String?) async throws -> Data {
+            lastMethod = method
+            lastOriginator = originator
+            if let obj = try JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                lastBody = obj
+            }
+            if let error { throw error }
+            return try JSONSerialization.data(withJSONObject: response, options: [])
+        }
+    }
+
+    // MARK: - getPublicKey
+
+    func testGetPublicKeyEncodesRequestAndDecodesResponse() async throws {
+        let mock = MockSubstrate()
+        let identity = PublicKey.fromPrivateKey(PrivateKey.random()!)
+        mock.response = ["publicKey": identity.hex]
+
+        let client = WalletClient(substrate: mock, originator: "app.example.com")
+        let result = try await client.getPublicKey(args: GetPublicKeyArgs(identityKey: true))
+        XCTAssertEqual(result.publicKey, identity)
+        XCTAssertEqual(mock.lastMethod, "getPublicKey")
+        XCTAssertEqual(mock.lastOriginator, "app.example.com")
+        XCTAssertEqual(mock.lastBody?["identityKey"] as? Bool, true)
+    }
+
+    // MARK: - encrypt
+
+    func testEncryptSendsEncodedProtocolAndBytes() async throws {
+        let mock = MockSubstrate()
+        let expected = Data([0xDE, 0xAD, 0xBE, 0xEF])
+        mock.response = ["ciphertext": Array(expected)]
+
+        let client = WalletClient(substrate: mock)
+        let plaintext = Data([0x01, 0x02, 0x03])
+        let result = try await client.encrypt(args: WalletEncryptArgs(
+            encryption: WalletEncryptionArgs(
+                protocolID: WalletProtocol(securityLevel: .app, protocol: "example protocol"),
+                keyID: "k1",
+                counterparty: .`self`
+            ),
+            plaintext: plaintext
+        ))
+
+        XCTAssertEqual(result.ciphertext, expected)
+        XCTAssertEqual(mock.lastMethod, "encrypt")
+        // Protocol ID serialised as [level, name].
+        let protoArray = mock.lastBody?["protocolID"] as? [Any]
+        XCTAssertEqual(protoArray?.count, 2)
+        XCTAssertEqual(protoArray?[0] as? Int, 1)
+        XCTAssertEqual(protoArray?[1] as? String, "example protocol")
+        XCTAssertEqual(mock.lastBody?["counterparty"] as? String, "self")
+        // Plaintext serialised as byte array.
+        let sent = mock.lastBody?["plaintext"] as? [Int]
+        XCTAssertEqual(sent, plaintext.map { Int($0) })
+    }
+
+    // MARK: - verifyHmac
+
+    func testVerifyHmacThrowsOnInvalid() async throws {
+        let mock = MockSubstrate()
+        mock.response = ["valid": false]
+        let client = WalletClient(substrate: mock)
+        do {
+            _ = try await client.verifyHmac(args: VerifyHmacArgs(
+                encryption: WalletEncryptionArgs(
+                    protocolID: WalletProtocol(securityLevel: .silent, protocol: "hmac test"),
+                    keyID: "1"
+                ),
+                data: Data([0x00]),
+                hmac: Data(repeating: 0x01, count: 32)
+            ))
+            XCTFail("expected invalidHmac")
+        } catch WalletError.invalidHmac {
+            // expected
+        }
+    }
+
+    // MARK: - error envelope handling
+
+    func testRemoteErrorEnvelopeMapsToWalletError() async throws {
+        let mock = MockSubstrate()
+        mock.response = [
+            "status": "error",
+            "code": 6,
+            "description": "invalid protocolID"
+        ]
+
+        // The substrate decides that 2xx+status:error is an error — we need
+        // the HTTP substrate path for that, so here we simulate by throwing
+        // directly from the mock:
+        mock.error = WalletError.invalidParameter(name: "protocolID", message: "invalid protocolID")
+
+        let client = WalletClient(substrate: mock)
+        do {
+            _ = try await client.getPublicKey(args: GetPublicKeyArgs(identityKey: true))
+            XCTFail("expected error")
+        } catch WalletError.invalidParameter(let name, _) {
+            XCTAssertEqual(name, "protocolID")
+        }
+    }
+
+    // MARK: - byte serialisation helpers
+
+    func testDecodeBytesAcceptsHexAndArray() {
+        XCTAssertEqual(WalletClient.decodeBytes([1, 2, 3]), Data([1, 2, 3]))
+        XCTAssertEqual(WalletClient.decodeBytes("deadbeef"), Data([0xde, 0xad, 0xbe, 0xef]))
+        XCTAssertNil(WalletClient.decodeBytes(nil))
+    }
+}


### PR DESCRIPTION
## Summary

Phase 8 completes HLR #1 — the Swift BSV SDK port. Ports the declarative wallet/auth/overlay surface from ts-sdk, plus Shamir secret sharing for private keys.

- **Wallet** — BRC-100 ProtoWallet, KeyDeriver, CachedKeyDeriver, WalletClient, SimplifiedFetchTransport, WalletError hierarchy
- **Auth** — BRC-66 Peer, SessionManager, BRC-103/104 Certificate hierarchy (Certificate, MasterCertificate, VerifiableCertificate with keyrings for selective disclosure), Transport protocol + SimplifiedFetchTransport
- **Overlay** — SHIPBroadcaster (implements Phase 5 `Broadcaster`), LookupResolver, HostReputationTracker (EMA latency + exponential backoff), OverlayAdminTokenTemplate, Historian, withDoubleSpendRetry
- **Shamir** — Polynomial, PointInFiniteField, KeyShares, PrivateKey.split / fromKeyShares / toBackupShares. Arithmetic mod P to match ts-sdk/go-sdk for cross-SDK backup interoperability.

## Architecture

Stays declarative throughout — protocols and adapters, no orchestration. The imperative "run a wallet" layer belongs in the companion macOS app. Matches ts-sdk `src/wallet/`, `src/auth/`, `src/overlay-tools/`, and `src/primitives/Polynomial.ts` + `PrivateKey.split`.

## Test plan

- [x] 465 tests, 0 failures (up from 380; 85 new)
- [x] BRC-42 key derivation vectors passing (existing, now also via KeyDeriver)
- [x] BRC-103 certificate round-trip + tamper rejection
- [x] BRC-66 Peer handshake round-trip
- [x] Shamir round-trip, threshold enforcement, order independence, cross-SDK share bundle decode
- [x] Overlay tracker math, admin token round-trip, dedupe, retry wrapper
- [x] \`swift build\` clean, \`swift test\` all pass

Closes HLR #1.

Per-task issue closures are in the individual commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)